### PR TITLE
Fix things for better JDK 11 compatibility

### DIFF
--- a/hubspot-style/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
+++ b/hubspot-style/src/main/resources/META-INF/extensions/org.immutables.inhibit-classpath
@@ -1,1 +1,2 @@
 com.google.errorprone.annotations.
+javax.annotation.Generated

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>18.2</version>
+    <version>25.3</version>
   </parent>
 
   <groupId>com.hubspot.immutables</groupId>


### PR DESCRIPTION
This does a few things to help with building this and generated code on JDK 11. I'm happy to make separate PRs if that'd be better.

## basepom upgrade

This upgrades the basepom version to pickup https://github.com/HubSpot/basepom/pull/67 and a findbugs patch version upgrade

## Block `javax.annotation.Generated`
This blocks `javax.annotation.Generated` (removed from the JDK) from the classpath used for determining what can and can't be generated, which will cause it to be omitted from generated classes. Rather confusingly, this doesn't cause any actual build problems, but causes some red when looking at generated code in IntelliJ. Omitting this annotation seems fine to be, but perhaps there's something I'm missing.

---
@ldriscoll @jhaber @kmclarnon @lorcanthrope 
