### PR TITLE
Add proof of concept WireSafeEnum utility

### DIFF
--- a/hubspot-style/pom.xml
+++ b/hubspot-style/pom.xml
@@ -17,6 +17,10 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -122,6 +122,14 @@ public final class WireSafeEnum<T extends Enum<T>> {
   private static <T extends Enum<T>> void initializeCache(Class<T> enumType) {
     T[] enumConstants = enumType.getEnumConstants();
     ArrayNode stringArray = MAPPER.valueToTree(enumConstants);
+    /*
+    Convert the enum constants to JSON and then back, in case this
+    mapping is not bijective. For example, two enum constants might
+    both be aliased to the same JSON value. When we encounter such
+    a JSON value, we'll defer to the enum's deserialization behavior.
+    This should match the behavior if the enum wasn't wrapped in
+    WireSafeEnum.
+     */
     T[] deserializedConstants = MAPPER.convertValue(
         stringArray,
         MAPPER.getTypeFactory().constructArrayType(enumType)
@@ -149,6 +157,10 @@ public final class WireSafeEnum<T extends Enum<T>> {
 
       WireSafeEnum<T> wireSafeEnum = new WireSafeEnum<>(enumType, jsonValue, enumValue);
       enumMap.put(enumValue, wireSafeEnum);
+      /*
+      If the deserialized value doesn't match, then this enum
+      is probably some sort of alias
+       */
       if (enumValue == deserializedValue) {
         jsonMap.put(jsonValue, wireSafeEnum);
       }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -149,15 +149,9 @@ public final class WireSafeEnum<T extends Enum<T>> {
 
       WireSafeEnum<T> wireSafeEnum = new WireSafeEnum<>(enumType, jsonValue, enumValue);
       enumMap.put(enumValue, wireSafeEnum);
-
-      final WireSafeEnum<T> deserializedVersion;
       if (enumValue == deserializedValue) {
-        deserializedVersion = wireSafeEnum;
-      } else {
-        deserializedVersion = new WireSafeEnum<>(enumType, jsonValue, deserializedValue);
+        jsonMap.put(jsonValue, wireSafeEnum);
       }
-
-      jsonMap.put(jsonValue, deserializedVersion);
     }
 
     ENUM_LOOKUP_CACHE.put(enumType, enumMap);

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -1,0 +1,110 @@
+package com.hubspot.immutables.utils;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.hubspot.immutables.utils.WireSafeEnum.Deserializer;
+
+@JsonDeserialize(using = Deserializer.class)
+public final class WireSafeEnum<T extends Enum<T>> {
+  private final Class<T> enumType;
+  private final String stringValue;
+  private final Optional<T> enumValue;
+
+  private WireSafeEnum(Class<T> enumType, String stringValue) {
+    this.enumType = enumType;
+    this.stringValue = stringValue;
+    this.enumValue = tryParse(enumType, stringValue);
+  }
+
+  @SuppressWarnings("unchecked")
+  private WireSafeEnum(T value) {
+    this.enumType = (Class<T>) value.getClass();
+    this.stringValue = value.name();
+    this.enumValue = Optional.of(value);
+  }
+
+  public static <T extends Enum<T>> WireSafeEnum<T> of(T value) {
+    return new WireSafeEnum<>(value);
+  }
+
+  public static <T extends Enum<T>> WireSafeEnum<T> of(String value, Class<T> enumType) {
+    return new WireSafeEnum<>(enumType, value);
+  }
+
+  public Class<T> enumType() {
+    return enumType;
+  }
+
+  @JsonValue
+  public String asString() {
+    return stringValue;
+  }
+
+  public Optional<T> asEnum() {
+    return enumValue;
+  }
+
+  private static <T extends Enum<T>> Optional<T> tryParse(Class<T> enumType, String stringValue) {
+    // TODO use Guava's Enums#getIfPresent or a similar approach
+    try {
+      return Optional.of(Enum.valueOf(enumType, stringValue));
+    } catch (IllegalArgumentException e) {
+      return Optional.empty();
+    }
+  }
+
+  public static class Deserializer extends JsonDeserializer<WireSafeEnum<?>> implements ContextualDeserializer {
+
+    @Override
+    public WireSafeEnum<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+      throw ctxt.mappingException("Expected createContextual to be called");
+    }
+
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+      JavaType contextualType = ctxt.getContextualType();
+      if (contextualType == null || !contextualType.hasRawClass(WireSafeEnum.class)) {
+        throw ctxt.mappingException("Can not handle contextualType: " + contextualType);
+      } else {
+        JavaType[] typeParameters = contextualType.findTypeParameters(WireSafeEnum.class);
+        if (typeParameters.length != 1) {
+          throw ctxt.mappingException("Can not discover enum type for: " + contextualType);
+        } else if (!typeParameters[0].isEnumType()) {
+          throw ctxt.mappingException("Can not handle non-enum type: " + typeParameters[0].getRawClass());
+        } else {
+          return deserializerFor(typeParameters[0].getRawClass());
+        }
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Enum<T>> JsonDeserializer<WireSafeEnum<T>> deserializerFor(Class<?> rawType) {
+      Class<T> enumType = (Class<T>) rawType;
+      // TODO cache these in a map?
+      return new JsonDeserializer<WireSafeEnum<T>>() {
+
+        @Override
+        public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+          if (p.getCurrentToken() == JsonToken.VALUE_STRING) {
+            return WireSafeEnum.of(p.getText(), enumType);
+          } else {
+            throw ctxt.wrongTokenException(p, JsonToken.VALUE_STRING, null);
+          }
+        }
+      };
+    }
+  }
+}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -45,7 +45,12 @@ public final class WireSafeEnum<T extends Enum<T>> {
     ensureCacheInitialized(enumType);
     WireSafeEnum<?> cached = ENUM_LOOKUP_CACHE.get(enumType).get(value.name());
     if (cached == null) {
-      throw new IllegalStateException("");
+      String message = String.format(
+          "Logic error in caching, no cached value found for %s.%s",
+          enumType,
+          value.name()
+      );
+      throw new IllegalStateException(message);
     } else {
       return (WireSafeEnum<T>) cached;
     }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -127,7 +127,7 @@ public final class WireSafeEnum<T extends Enum<T>> {
     mapping is not bijective. For example, two enum constants might
     both be aliased to the same JSON value. When we encounter such
     a JSON value, we'll defer to the enum's deserialization behavior.
-    This should match the behavior if the enum wasn't wrapped in
+    This should match the behavior as if the enum wasn't wrapped in
     WireSafeEnum.
      */
     T[] deserializedConstants = MAPPER.convertValue(

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -24,7 +24,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromKnownString() {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("SOURCE", RetentionPolicy.class);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "SOURCE");
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
@@ -32,7 +32,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromUnknownString() {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("INVALID", RetentionPolicy.class);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "INVALID");
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("INVALID");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
@@ -43,13 +43,13 @@ public class WireSafeEnumTest {
     WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
 
-    wrapper = WireSafeEnum.of("SOURCE", RetentionPolicy.class);
+    wrapper = WireSafeEnum.of(RetentionPolicy.class, "SOURCE");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
   }
 
   @Test
   public void itSerializesUnknownValueAsString() throws IOException {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("INVALID", RetentionPolicy.class);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "INVALID");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"INVALID\"");
   }
 

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -96,7 +96,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itDoesntAllowNumericJsonValues() {
-    Throwable t = catchThrowable(() -> WireSafeEnum.fromEnum(NumericJsonEnum.ABC));
+    Throwable t = catchThrowable(() -> WireSafeEnum.of(NumericJsonEnum.ABC));
     assertThat(t)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("NumericJsonEnum");
@@ -105,7 +105,7 @@ public class WireSafeEnumTest {
   @Test
   public void itBuildsFromEnum() {
     WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromEnum(RetentionPolicy.SOURCE);
+        WireSafeEnum.of(RetentionPolicy.SOURCE);
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
@@ -114,7 +114,7 @@ public class WireSafeEnumTest {
   @Test
   public void itBuildsFromEnumWithCustomJson() {
     WireSafeEnum<CustomJsonEnum> wrapper =
-        WireSafeEnum.fromEnum(CustomJsonEnum.ABC);
+        WireSafeEnum.of(CustomJsonEnum.ABC);
     assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("CBA");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
@@ -194,7 +194,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itSerializesKnownValueAsString() throws IOException {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromEnum(RetentionPolicy.SOURCE);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
 
     wrapper = WireSafeEnum.fromJson(RetentionPolicy.class, "SOURCE");
@@ -203,7 +203,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itSerializesKnownValueAsStringWithCustomJson() throws IOException {
-    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromEnum(CustomJsonEnum.ABC);
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.of(CustomJsonEnum.ABC);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"CBA\"");
 
     wrapper = WireSafeEnum.fromJson(CustomJsonEnum.class, "CBA");
@@ -215,7 +215,7 @@ public class WireSafeEnumTest {
     WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(CollidingJsonEnum.class, "123");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"123\"");
 
-    wrapper = WireSafeEnum.fromEnum(CollidingJsonEnum.ABC);
+    wrapper = WireSafeEnum.of(CollidingJsonEnum.ABC);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"123\"");
   }
 
@@ -225,7 +225,7 @@ public class WireSafeEnumTest {
         WireSafeEnum.fromJson(CollidingJsonEnumWithCreator.class, "123");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"123\"");
 
-    wrapper = WireSafeEnum.fromEnum(CollidingJsonEnumWithCreator.ABC);
+    wrapper = WireSafeEnum.of(CollidingJsonEnumWithCreator.ABC);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"123\"");
   }
 

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -1,0 +1,77 @@
+package com.hubspot.immutables.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Optional;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class WireSafeEnumTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  public void itBuildsFromEnum() {
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
+    assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+    assertThat(wrapper.asString()).isEqualTo("SOURCE");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
+  }
+
+  @Test
+  public void itBuildsFromKnownString() {
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("SOURCE", RetentionPolicy.class);
+    assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+    assertThat(wrapper.asString()).isEqualTo("SOURCE");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
+  }
+
+  @Test
+  public void itBuildsFromUnknownString() {
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("INVALID", RetentionPolicy.class);
+    assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+    assertThat(wrapper.asString()).isEqualTo("INVALID");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void itSerializesKnownValueAsString() throws IOException {
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
+
+    wrapper = WireSafeEnum.of("SOURCE", RetentionPolicy.class);
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
+  }
+
+  @Test
+  public void itSerializesUnknownValueAsString() throws IOException {
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of("INVALID", RetentionPolicy.class);
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"INVALID\"");
+  }
+
+  @Test
+  public void itDeserializesFromKnownString() throws IOException {
+    WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
+        "\"SOURCE\"",
+        new TypeReference<WireSafeEnum<RetentionPolicy>>() {}
+    );
+    assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+    assertThat(wrapper.asString()).isEqualTo("SOURCE");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
+  }
+
+  @Test
+  public void itDeserializesFromUnknownString() throws IOException {
+    WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
+        "\"INVALID\"",
+        new TypeReference<WireSafeEnum<RetentionPolicy>>() {}
+    );
+    assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+    assertThat(wrapper.asString()).isEqualTo("INVALID");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+  }
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -1,6 +1,7 @@
 package com.hubspot.immutables.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.IOException;
 import java.lang.annotation.RetentionPolicy;
@@ -8,49 +9,150 @@ import java.util.Optional;
 
 import org.junit.Test;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class WireSafeEnumTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  public enum CustomJsonEnum {
+    ABC, DEF;
+
+    @JsonValue
+    public String reversedName() {
+      return new StringBuilder(name()).reverse().toString();
+    }
+  }
+
+  public enum NullJsonEnum {
+    ABC, DEF;
+
+    @JsonValue
+    public String jsonName() {
+      if (this == DEF) {
+        return null;
+      } else {
+        return name();
+      }
+    }
+  }
+
+  public enum CollidingJsonEnum {
+    ABC, DEF;
+
+    @JsonValue
+    public String jsonName() {
+      return "123";
+    }
+  }
+
+  @Test
+  public void itParsesNullAsNull() throws IOException {
+    WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
+        "null",
+        new TypeReference<WireSafeEnum<RetentionPolicy>>() {}
+    );
+    assertThat(wrapper).isNull();
+  }
+
+  @Test
+  public void itDoesntAllowNullJsonValues() {
+    Throwable t = catchThrowable(() -> WireSafeEnum.fromJson(NullJsonEnum.class, "ABC"));
+    assertThat(t)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("NullJsonEnum")
+        .hasMessageContaining("DEF")
+        .hasMessageContaining("null");
+  }
+
+  @Test
+  public void itDoesntAllowCollidingJsonValues() {
+    Throwable t = catchThrowable(() -> WireSafeEnum.fromJson(CollidingJsonEnum.class, "123"));
+    assertThat(t)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("CollidingJsonEnum")
+        .hasMessageContaining("ABC")
+        .hasMessageContaining("DEF")
+        .hasMessageContaining("123");
+  }
+
   @Test
   public void itBuildsFromEnum() {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromEnum(RetentionPolicy.SOURCE);
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
+  }
+
+  @Test
+  public void itBuildsFromEnumWithCustomJson() {
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromEnum(CustomJsonEnum.ABC);
+    assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+    assertThat(wrapper.asString()).isEqualTo("CBA");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
   }
 
   @Test
   public void itBuildsFromKnownString() {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "SOURCE");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(RetentionPolicy.class, "SOURCE");
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
   }
 
   @Test
+  public void itBuildsFromKnownStringWithCustomJson() {
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(CustomJsonEnum.class, "CBA");
+    assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+    assertThat(wrapper.asString()).isEqualTo("CBA");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
+  }
+
+  @Test
   public void itBuildsFromUnknownString() {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "INVALID");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID");
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("INVALID");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
   }
 
   @Test
+  public void itBuildsFromUnknownStringWithCustomJson() {
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(CustomJsonEnum.class, "ABC");
+    assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+    assertThat(wrapper.asString()).isEqualTo("ABC");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+  }
+
+  @Test
   public void itSerializesKnownValueAsString() throws IOException {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromEnum(RetentionPolicy.SOURCE);
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
 
-    wrapper = WireSafeEnum.of(RetentionPolicy.class, "SOURCE");
+    wrapper = WireSafeEnum.fromJson(RetentionPolicy.class, "SOURCE");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"SOURCE\"");
   }
 
   @Test
+  public void itSerializesKnownValueAsStringWithCustomJson() throws IOException {
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromEnum(CustomJsonEnum.ABC);
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"CBA\"");
+
+    wrapper = WireSafeEnum.fromJson(CustomJsonEnum.class, "CBA");
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"CBA\"");
+  }
+
+  @Test
   public void itSerializesUnknownValueAsString() throws IOException {
-    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.class, "INVALID");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID");
     assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"INVALID\"");
+  }
+
+  @Test
+  public void itSerializesUnknownValueAsStringWithCustomJson() throws IOException {
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(CustomJsonEnum.class, "ABC");
+    assertThat(MAPPER.writeValueAsString(wrapper)).isEqualTo("\"ABC\"");
   }
 
   @Test
@@ -65,6 +167,17 @@ public class WireSafeEnumTest {
   }
 
   @Test
+  public void itDeserializesFromKnownStringWithCustomJson() throws IOException {
+    WireSafeEnum<CustomJsonEnum> wrapper = MAPPER.readValue(
+        "\"CBA\"",
+        new TypeReference<WireSafeEnum<CustomJsonEnum>>() {}
+    );
+    assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+    assertThat(wrapper.asString()).isEqualTo("CBA");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
+  }
+
+  @Test
   public void itDeserializesFromUnknownString() throws IOException {
     WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
         "\"INVALID\"",
@@ -72,6 +185,17 @@ public class WireSafeEnumTest {
     );
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("INVALID");
+    assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void itDeserializesFromUnknownStringWithCustomJson() throws IOException {
+    WireSafeEnum<CustomJsonEnum> wrapper = MAPPER.readValue(
+        "\"ABC\"",
+        new TypeReference<WireSafeEnum<CustomJsonEnum>>() {}
+    );
+    assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+    assertThat(wrapper.asString()).isEqualTo("ABC");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
   }
 }


### PR DESCRIPTION
Related to the discussions we've been having about making use of enums in REST APIs safer. This adds `WireSafeEnum` which is a wrapper that maintains the string value for forward compatibility, as well as a method that exposes the optional enum constant. There are some usage examples in the tests:
https://github.com/HubSpot/hubspot-immutables/blob/0cfe1cc2179e44f6e4b3aeaee7fcf55935919022/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java#L17-L39

The intent is for people to use this in their Immutables, so to improve discoverability I think it may make sense to just define this utility in the hubspot-style module so anyone using `@HubSpotStyle` immediately has access to it. 

@zklapow @kmclarnon @stevegutz @ldriscoll @axiak @jschlather 