### PR TITLE
Add an asEnumOrThrow method

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -2,6 +2,7 @@ package com.hubspot.immutables.utils;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +10,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 
@@ -52,8 +54,6 @@ public final class WireSafeEnum<T extends Enum<T>> {
   private static final Map<Class<?>, Map<?, WireSafeEnum<?>>> ENUM_LOOKUP_CACHE =
       new ConcurrentHashMap<>();
   private static final Map<Class<?>, Map<String, WireSafeEnum<?>>> JSON_LOOKUP_CACHE =
-      new ConcurrentHashMap<>();
-  private static final Map<Class<?>, String> VALID_MEMBERS_CACHE =
       new ConcurrentHashMap<>();
 
   private final Class<T> enumType;
@@ -117,16 +117,28 @@ public final class WireSafeEnum<T extends Enum<T>> {
   }
 
   @Nonnull
-  public T asEnumOrThrow() {
+  public <X extends Throwable> T asEnumOrThrow(Supplier<? extends X> exceptionSupplier) throws X {
     return asEnum()
-        .orElseThrow(this::getInvalidValueException);
+        .orElseThrow(exceptionSupplier);
+  }
+
+  @Nonnull
+  public T asEnumOrThrow() {
+    return asEnumOrThrow(this::getInvalidValueException);
   }
 
   private IllegalStateException getInvalidValueException() {
-    ensureValidMembersCacheInitialized(enumType);
+    ensureJsonCacheInitialized(enumType);
+
+    Collection<WireSafeEnum<?>> wiresafeEnumTypes = JSON_LOOKUP_CACHE.get(enumType).values();
+    String validMembers = Arrays.toString(wiresafeEnumTypes.stream()
+        .map(WireSafeEnum::asString)
+        .distinct()
+        .sorted()
+        .toArray());
 
     String message = String.format("Value '%s' is not valid for enum of type '%s'. Valid values are: %s",
-        jsonValue, enumType.getSimpleName(), VALID_MEMBERS_CACHE.get(enumType));
+        jsonValue, enumType.getSimpleName(), validMembers);
 
     return new IllegalStateException(message);
   }
@@ -181,12 +193,6 @@ public final class WireSafeEnum<T extends Enum<T>> {
     }
   }
 
-  private static <T extends Enum<T>> void ensureValidMembersCacheInitialized(Class<T> enumType) {
-    if (!VALID_MEMBERS_CACHE.containsKey(enumType)) {
-      initializeCache(enumType);
-    }
-  }
-
   private static <T extends Enum<T>> void initializeCache(Class<T> enumType) {
     T[] enumConstants = enumType.getEnumConstants();
     ArrayNode stringArray = MAPPER.valueToTree(enumConstants);
@@ -236,14 +242,6 @@ public final class WireSafeEnum<T extends Enum<T>> {
 
     ENUM_LOOKUP_CACHE.put(enumType, enumMap);
     JSON_LOOKUP_CACHE.put(enumType, jsonMap);
-
-    String validMembers = Arrays.toString(jsonMap.values().stream()
-        .map(WireSafeEnum::asString)
-        .distinct()
-        .sorted()
-        .toArray());
-
-    VALID_MEMBERS_CACHE.put(enumType, validMembers);
   }
 
   // adapted from Guava

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -128,8 +128,6 @@ public final class WireSafeEnum<T extends Enum<T>> {
   }
 
   private IllegalStateException getInvalidValueException() {
-    ensureJsonCacheInitialized(enumType);
-
     Collection<WireSafeEnum<?>> wiresafeEnumTypes = JSON_LOOKUP_CACHE.get(enumType).values();
     String validMembers = Arrays.toString(wiresafeEnumTypes.stream()
         .map(WireSafeEnum::asString)

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -3,7 +3,6 @@ package com.hubspot.immutables.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.annotation.RetentionPolicy;
@@ -366,11 +365,7 @@ public class WireSafeEnumTest {
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
 
-    try {
-      assertThat(wrapper.asEnumOrThrow())
-          .isEqualTo(RetentionPolicy.SOURCE);
-    } catch (IllegalStateException e) {
-      fail("IllegalStateException should not have been thrown", e);
-    }
+    assertThat(wrapper.asEnumOrThrow())
+        .isEqualTo(RetentionPolicy.SOURCE);
   }
 }


### PR DESCRIPTION
One thing I've found myself doing while using this class is throwing an exception if the value isn't valid for the enum. I don't always do this, but it's useful in certain cases where there's no correct "default" action, and the proper thing to do is still to throw and abort whatever we're trying to do.

With that in mind, I created a helper method `asEnumOrThrow` which just removes the boilerplate of calling Optional::orElseThrow with a useful exception.