### PR TITLE
Fix encoding version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>immutable-collection-encodings</artifactId>
-        <version>1.0-immutable-encoding-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.immutables</groupId>


### PR DESCRIPTION
I don't believe there have been [any relevant changes](https://github.com/HubSpot/hubspot-immutables/compare/a9e55e00359378ecdb185f266e9e30d0aa7e4b72..master) to the encodings stuff since this branch was set up so I think this should be safe.  I plan on mothership'ing these versions before merging

@stevegutz @Xcelled @snommit-mit 