### PR TITLE
Handle enum subtypes in WireSafeEnum

### DIFF
--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -76,7 +76,7 @@ public class WireSafeEnumTest {
     }
   }
 
-  public enum SubclassedEnum {
+  public enum EnumWithOverride {
     ABC,
     DEF {
       @Override
@@ -92,12 +92,12 @@ public class WireSafeEnumTest {
   }
 
   @Test
-  public void itHandlesSubclassedEnums() {
-    WireSafeEnum<SubclassedEnum> abc = WireSafeEnum.of(SubclassedEnum.ABC);
-    WireSafeEnum<SubclassedEnum> def = WireSafeEnum.of(SubclassedEnum.DEF);
+  public void itHandlesEnumsWithOverrides() {
+    WireSafeEnum<EnumWithOverride> abc = WireSafeEnum.of(EnumWithOverride.ABC);
+    WireSafeEnum<EnumWithOverride> def = WireSafeEnum.of(EnumWithOverride.DEF);
 
-    assertThat(abc.asEnum()).contains(SubclassedEnum.ABC);
-    assertThat(def.asEnum()).contains(SubclassedEnum.DEF);
+    assertThat(abc.asEnum()).contains(EnumWithOverride.ABC);
+    assertThat(def.asEnum()).contains(EnumWithOverride.DEF);
   }
 
   @Test

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -76,6 +76,30 @@ public class WireSafeEnumTest {
     }
   }
 
+  public enum SubclassedEnum {
+    ABC,
+    DEF {
+      @Override
+      public String getSomething() {
+        return "b";
+      }
+    }
+    ;
+
+    public String getSomething() {
+      return "a";
+    }
+  }
+
+  @Test
+  public void itHandlesSubclassedEnums() {
+    WireSafeEnum<SubclassedEnum> abc = WireSafeEnum.of(SubclassedEnum.ABC);
+    WireSafeEnum<SubclassedEnum> def = WireSafeEnum.of(SubclassedEnum.DEF);
+
+    assertThat(abc.asEnum()).contains(SubclassedEnum.ABC);
+    assertThat(def.asEnum()).contains(SubclassedEnum.DEF);
+  }
+
   @Test
   public void itParsesNullAsNull() throws IOException {
     WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(


### PR DESCRIPTION
I discovered this issue during testing for https://github.com/HubSpot/Rosetta/pull/77.  The added test case demonstrates the error, which would previously cause a jackson issue because `getEnumConstants()` on a enum constant subclass (`com.hubspot.immutables.utils.WireSafeEnumTest$SubclassedEnum$1` in the test) returns null.

@jhaber @stevegutz @Xcelled @snommit-mit 