### PR TITLE
Use @FormatMethod in ImmutableConditions

### DIFF
--- a/immutables-exceptions/pom.xml
+++ b/immutables-exceptions/pom.xml
@@ -15,5 +15,9 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
+++ b/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
@@ -1,5 +1,8 @@
 package com.hubspot.immutables.validation;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
 import java.util.Collection;
 import java.util.Optional;
 
@@ -7,27 +10,32 @@ import javax.annotation.Nonnull;
 
 public class ImmutableConditions {
 
-  public static void checkValid(boolean expression, String template, Object... arguments) {
+  @FormatMethod
+  public static void checkValid(boolean expression, @FormatString String template, Object... arguments) {
     if (!expression) {
       throw new InvalidImmutableStateException(String.format(template, arguments));
     }
   }
 
-  public static void checkNotEmpty(Collection<?> collection, String template, Object... arguments) {
+  @FormatMethod
+  public static void checkNotEmpty(Collection<?> collection, @FormatString String template, Object... arguments) {
     checkValid(!collection.isEmpty(), template, arguments);
   }
 
-  public static void checkNotEmpty(String string, String template, Object... arguments) {
+  @FormatMethod
+  public static void checkNotEmpty(String string,@FormatString String template, Object... arguments) {
     checkValid(!string.isEmpty(), template, arguments);
   }
 
   @Nonnull
-  public static <T> T checkNotNull(T ref, String template, Object... arguments) {
+  @FormatMethod
+  public static <T> T checkNotNull(T ref, @FormatString String template, Object... arguments) {
     checkValid(ref != null, template, arguments);
     return ref;
   }
 
-  public static <T> T checkPresent(Optional<T> maybe, String template, Object... arguments) {
+  @FormatMethod
+  public static <T> T checkPresent(Optional<T> maybe, @FormatString String template, Object... arguments) {
     checkValid(maybe.isPresent(), template, arguments);
     return maybe.get();
   }


### PR DESCRIPTION
This will allow us to use error-prone to validate arguments. I'll be rolling this out such that we don't break any builds.

@kmclarnon @Xcelled @snommit-mit 