### PR TITLE
Support additional/alternative json value

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -240,6 +240,15 @@ public final class WireSafeEnum<T extends Enum<T>> {
       if (enumValue == deserializedValue) {
         jsonMap.put(jsonValue, wireSafeEnum);
       }
+
+      if (enumValue instanceof WireSafeEnumAlternativeJsonInputValue) {
+        String alternativeJsonInputValue = ((WireSafeEnumAlternativeJsonInputValue) enumValue).getExtraJsonInputValue();
+        if (alternativeJsonInputValue != null && !alternativeJsonInputValue.isEmpty() && !alternativeJsonInputValue.equals(jsonValue)) {
+          WireSafeEnum<T> wireSafeEnumForAlternativeInput = new WireSafeEnum<>(enumType, alternativeJsonInputValue, enumValue);
+          enumMap.put(enumValue, wireSafeEnumForAlternativeInput);
+          jsonMap.put(alternativeJsonInputValue, wireSafeEnumForAlternativeInput);
+        }
+      }
     }
 
     ENUM_LOOKUP_CACHE.put(enumType, enumMap);

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnumAlternativeJsonInputValue.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnumAlternativeJsonInputValue.java
@@ -1,0 +1,11 @@
+package com.hubspot.immutables.utils;
+
+/**
+ * This interface is to provide support for cases where the json value in one system
+ * is different from the json value in another system.
+ * For example, lower case vs upper case.
+ * This adds some of the functionality that a @JsonCreator-annotated method would allow
+ */
+public interface WireSafeEnumAlternativeJsonInputValue {
+    String getExtraJsonInputValue();
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -91,6 +91,16 @@ public class WireSafeEnumTest {
     }
   }
 
+  public enum EnumWithAlternativeJson implements WireSafeEnumAlternativeJsonInputValue {
+    ABC,
+    DEF;
+
+    @Override
+    public String getExtraJsonInputValue() {
+      return name().toLowerCase();
+    }
+  }
+
   @Test
   public void itHandlesEnumsWithOverrides() {
     WireSafeEnum<EnumWithOverride> abc = WireSafeEnum.of(EnumWithOverride.ABC);
@@ -391,5 +401,16 @@ public class WireSafeEnumTest {
 
     assertThat(wrapper.asEnumOrThrow())
         .isEqualTo(RetentionPolicy.SOURCE);
+  }
+
+  @Test
+  public void itDeserializesFromAlternativeJsonValue() {
+    WireSafeEnum<EnumWithAlternativeJson> wrapperForStandard =
+        WireSafeEnum.fromJson(EnumWithAlternativeJson.class, EnumWithAlternativeJson.DEF.name());
+    WireSafeEnum<EnumWithAlternativeJson> wrapperForAlternative =
+        WireSafeEnum.fromJson(EnumWithAlternativeJson.class, EnumWithAlternativeJson.DEF.getExtraJsonInputValue());
+    assertThat(wrapperForAlternative.asEnumOrThrow())
+            .isEqualTo(wrapperForStandard.asEnumOrThrow())
+            .isEqualTo(EnumWithAlternativeJson.DEF);
   }
 }


### PR DESCRIPTION
Add proof of concept implementation of WireSafeEnum support for an additional json input value

We'd like to have Wiresafe enum read json with upper and lowercase versions of the value to support input from different systems that have cased them differently. This implementation uses an interface to provide an alternative string value. I could imagine alternative implementations that differ by
* using an marker annotation instead of an interface
* providing a transformation method instead of explicit alternative values.

Just wanted to see if we're open to this concept in general and go from there on the implementation