### PR TITLE
Support json creator

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -45,8 +45,7 @@ import javax.annotation.Nonnull;
  * there are some things to be aware of:
  * 1. every enum constant must serialize to JSON as a non-null string
  *    (serializing as a number or null is not supported)
- * 2. enums with custom @JsonCreator logic are poorly/not supported
- * 3. T and WireSafeEnum<T> are different types so migrating is a
+ * 2. T and WireSafeEnum<T> are different types so migrating is a
  *    breaking change from a code perspective and Java code usages
  *    of the field will need to get updated
  */


### PR DESCRIPTION
This PR attempts to provide full support for `@JsonCreator` and other more esoteric means of mapping json to enum values by falling back to jackson to deserialize the value if it does not exist in the cache.  We avoid adding  these to the cache here as the number of potential values that may map to enum constants is unbounded.

Depending on how frequently an application is operating on `WireSafeEnum` instances that contain an unknown enum constant, this could cause a noticeable decrease in performance.  I think the usability improvement is worth the cost but I'm certainly open to other options / solutions here.

This is a different approach that described in https://github.com/HubSpot/hubspot-immutables/pull/27 but I believe it covers the same usage patterns.

@Xcelled @snommit-mit @jhaber - thoughts?