### PR TITLE
Add @ImmutableInherited meta-annotation

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -24,7 +24,8 @@ import com.hubspot.immutables.validation.InvalidImmutableStateException;
     throwForInvalidImmutableState = InvalidImmutableStateException.class,
     optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
     forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
-    visibility = ImplementationVisibility.SAME // Generated class will have the same visibility as the abstract class/interface)
+    visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
+    passAnnotations = ImmutableInherited.class
 )
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
@@ -23,5 +23,7 @@ import com.hubspot.immutables.validation.InvalidImmutableStateException;
     optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
     forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
     visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-    jdkOnly = true)  // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+    jdkOnly = true,  // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+    passAnnotations = ImmutableInherited.class
+)
 public @interface HubSpotModifiableStyle {}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
@@ -23,5 +23,7 @@ import com.hubspot.immutables.validation.InvalidImmutableStateException;
     optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
     forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
     visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-    jdkOnly = true)  // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+    jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+    passAnnotations = ImmutableInherited.class
+)
 public @interface HubSpotStyle {}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/ImmutableInherited.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/ImmutableInherited.java
@@ -1,0 +1,11 @@
+package com.hubspot.immutables.style;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface ImmutableInherited {
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/InheritedAnnotationTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/InheritedAnnotationTest.java
@@ -1,0 +1,44 @@
+package com.hubspot.immutables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.hubspot.immutables.model.annotated.AnnotatedAbstractClass;
+import com.hubspot.immutables.model.annotated.AnnotatedImmutableStyleInterface;
+import com.hubspot.immutables.model.annotated.AnnotatedInterface;
+import com.hubspot.immutables.model.annotated.AnnotatedModifiableInterface;
+import com.hubspot.immutables.model.annotated.InheritedAnnotation;
+
+public class InheritedAnnotationTest {
+
+  @Test
+  public void itInherits() throws Exception {
+    checkAnnotations(AnnotatedInterface.class);
+    checkAnnotations(AnnotatedAbstractClass.class);
+    checkAnnotations(AnnotatedImmutableStyleInterface.class);
+    checkAnnotations(AnnotatedModifiableInterface.class);
+  }
+
+  private void checkAnnotations(Class<?> clazz) throws NoSuchMethodException {
+    InheritedAnnotation classAnnotation = clazz.getAnnotation(InheritedAnnotation.class);
+    assertThat(classAnnotation)
+      .as("%s is annotated", clazz.getSimpleName())
+      .isNotNull();
+    assertThat(classAnnotation.value())
+      .as("%s has correct annotation value", clazz.getSimpleName())
+      .isEqualTo("type");
+
+    InheritedAnnotation methodAnnotation = clazz.getMethod("getAnnotated").getAnnotation(InheritedAnnotation.class);
+    assertThat(methodAnnotation)
+      .as("%s#getAnnotated() is annotated", clazz.getSimpleName())
+      .isNotNull();
+    assertThat(methodAnnotation.value())
+      .as("%s#getAnnotated() has correct annotation value", clazz.getSimpleName())
+      .isEqualTo("method");
+
+    assertThat(clazz.getMethod("getUnannotated").getAnnotation(InheritedAnnotation.class))
+      .as("%s#getUnannotated() is not annotated", clazz.getSimpleName())
+      .isNull();
+  }
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedAbstractClassIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedAbstractClassIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.immutables.model.annotated;
+
+import org.immutables.value.Value;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Value.Immutable
+@HubSpotStyle
+@InheritedAnnotation("type")
+public abstract class AnnotatedAbstractClassIF {
+
+  @InheritedAnnotation("method")
+  public abstract int getAnnotated();
+
+  public abstract int getUnannotated();
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedImmutableStyleInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedImmutableStyleInterfaceIF.java
@@ -1,0 +1,15 @@
+package com.hubspot.immutables.model.annotated;
+
+import org.immutables.value.Value;
+
+import com.hubspot.immutables.style.HubSpotImmutableStyle;
+
+@Value.Immutable
+@HubSpotImmutableStyle
+@InheritedAnnotation("type")
+public interface AnnotatedImmutableStyleInterfaceIF {
+  @InheritedAnnotation("method")
+  int getAnnotated();
+
+  int getUnannotated();
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedInterfaceIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.immutables.model.annotated;
+
+import org.immutables.value.Value;
+
+import com.hubspot.immutables.style.HubSpotStyle;
+
+@Value.Immutable
+@HubSpotStyle
+@InheritedAnnotation("type")
+public interface AnnotatedInterfaceIF {
+
+  @InheritedAnnotation("method")
+  int getAnnotated();
+
+  int getUnannotated();
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedModifiableInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedModifiableInterfaceIF.java
@@ -1,0 +1,16 @@
+package com.hubspot.immutables.model.annotated;
+
+import org.immutables.value.Value;
+
+import com.hubspot.immutables.style.HubSpotModifiableStyle;
+
+@Value.Immutable
+@HubSpotModifiableStyle
+@InheritedAnnotation("type")
+public interface AnnotatedModifiableInterfaceIF {
+
+  @InheritedAnnotation("method")
+  int getAnnotated();
+
+  int getUnannotated();
+}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/InheritedAnnotation.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/InheritedAnnotation.java
@@ -1,0 +1,15 @@
+package com.hubspot.immutables.model.annotated;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.hubspot.immutables.style.ImmutableInherited;
+
+@ImmutableInherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface InheritedAnnotation {
+  String value();
+}


### PR DESCRIPTION
This adds the `@ImmutableInherited` meta-annotation. We can use this so that our annotations are inherited properly. Please let me know if you have any thoughts on naming.

@zklapow @kmclarnon @Xcelled @snommit-mit @suruuK @jhaber @ldriscoll (lotta tags 😅)