### PR TITLE
Deprecate asEnumOrThrow

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -128,13 +128,28 @@ public final class WireSafeEnum<T extends Enum<T>> {
     return enumValue;
   }
 
+  /**
+   * @deprecated this method doesn't handle unknown enum values, and eliminates the
+   * benefits of WireSafeEnum. If you want to compare to a specific value, you can
+   * call {@link #contains(Enum)}, which handles unknown values gracefully. If you do
+   * really need to coerce to an enum, you can replace this method with
+   * .asEnum().orElseThrow(exceptionSupplier)
+   */
   @Nonnull
+  @Deprecated
   public <X extends Throwable> T asEnumOrThrow(Supplier<? extends X> exceptionSupplier) throws X {
     return asEnum()
         .orElseThrow(exceptionSupplier);
   }
 
+  /**
+   * @deprecated this method doesn't handle unknown enum values, and eliminates the
+   * benefits of WireSafeEnum. If you want to compare to a specific value, you can
+   * call {@link #contains(Enum)}, which handles unknown values gracefully. If you do
+   * really need to coerce to an enum, you can replace this method with .asEnum().get()
+   */
   @Nonnull
+  @Deprecated
   public T asEnumOrThrow() {
     return asEnumOrThrow(this::getInvalidValueException);
   }


### PR DESCRIPTION
We're seeing this method get accidentally abused a lot within our codebase, which chips away at the benefits of `WireSafeEnum`. It seems like the risk of misuse outweighs the convenience of this method so we're going to work towards removing it in a future version (in the case where this is really the behavior you want, `asEnum().get()` is fewer characters anyway)

@stevie400 @Xcelled @suruuK @kmclarnon @aem 