### PR TITLE
Use Strings#lenientFormat in ImmutableConditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ public interface WidgetIF {
 
   @Value.Check
   default void widgetIdInFoo() {
-    ImmutableConditions.checkValid(getFoo().contains(getWidgetId()), "widgetId %d must be in Foo!", getWidgetId());
+    ImmutableConditions.checkValid(getFoo().contains(getWidgetId()), "widgetId %s must be in Foo!", getWidgetId());
   }
 }
 ```

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -1,4 +1,5 @@
 package com.hubspot.immutables.style;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/immutables-exceptions/pom.xml
+++ b/immutables-exceptions/pom.xml
@@ -15,5 +15,9 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
+++ b/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
@@ -5,11 +5,13 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.base.Strings;
+
 public class ImmutableConditions {
 
   public static void checkValid(boolean expression, String template, Object... arguments) {
     if (!expression) {
-      throw new InvalidImmutableStateException(String.format(template, arguments));
+      throw new InvalidImmutableStateException(Strings.lenientFormat(template, arguments));
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
     <dep.jackson.version>2.12.6</dep.jackson.version>
     <dep.jackson-databind.version>${dep.jackson.version}</dep.jackson-databind.version>
     <dep.immutables.version>2.8.8</dep.immutables.version>
+    <dep.guava.version>31.1-jre</dep.guava.version>
+    <dep.error-prone.version>2.11.0</dep.error-prone.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This makes `ImmutableConditions` compatible with `Preconditions`. I've already updated our internal codebase to use `%s` instead of other placeholders.

@zklapow @ldriscoll @jhaber @suruuK @Xcelled 