### PR TITLE
Add WireSafeEnum encoding support

### DIFF
--- a/hubspot-style-test/pom.xml
+++ b/hubspot-style-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.5-SNAPSHOT</version>
   </parent>
 
   <artifactId>hubspot-style-test</artifactId>

--- a/hubspot-style-test/pom.xml
+++ b/hubspot-style-test/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.hubspot.immutables</groupId>
+    <artifactId>hubspot-immutables</artifactId>
+    <version>1.4-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>hubspot-style-test</artifactId>
+
+  <properties>
+    <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>hubspot-style</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.hubspot.immutables</groupId>
+      <artifactId>immutables-exceptions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/hubspot-style-test/src/main/java/com/hubspot/immutables/InheritedEnum.java
+++ b/hubspot-style-test/src/main/java/com/hubspot/immutables/InheritedEnum.java
@@ -1,0 +1,12 @@
+package com.hubspot.immutables;
+
+import org.immutables.value.Value;
+
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public interface InheritedEnum {
+  @Value.Default
+  default WireSafeEnum<TestEnum> getFirstEnum() {
+    return WireSafeEnum.of(TestEnum.ONE);
+  }
+}

--- a/hubspot-style-test/src/main/java/com/hubspot/immutables/InheritedEnum.java
+++ b/hubspot-style-test/src/main/java/com/hubspot/immutables/InheritedEnum.java
@@ -1,12 +1,11 @@
 package com.hubspot.immutables;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.utils.WireSafeEnum;
+import org.immutables.value.Value;
 
 public interface InheritedEnum {
   @Value.Default
   default WireSafeEnum<TestEnum> getFirstEnum() {
-    return WireSafeEnum.of(TestEnum.ONE);
+    return WireSafeEnum.of(TestEnum.THREE);
   }
 }

--- a/hubspot-style-test/src/main/java/com/hubspot/immutables/TestEnum.java
+++ b/hubspot-style-test/src/main/java/com/hubspot/immutables/TestEnum.java
@@ -1,0 +1,7 @@
+package com.hubspot.immutables;
+
+public enum TestEnum {
+  ONE,
+  TWO,
+  THREE
+}

--- a/hubspot-style-test/src/main/java/com/hubspot/immutables/TestImmutableIF.java
+++ b/hubspot-style-test/src/main/java/com/hubspot/immutables/TestImmutableIF.java
@@ -1,0 +1,15 @@
+package com.hubspot.immutables;
+
+import org.immutables.value.Value.Immutable;
+
+import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
+import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+@Immutable
+@HubSpotStyle
+@WireSafeEnumEncodingEnabled
+public interface TestImmutableIF extends InheritedEnum {
+  String getString();
+  WireSafeEnum<TestEnum> getSecondEnum();
+}

--- a/hubspot-style-test/src/test/java/com/hubspot/immutables/WireSafeEncodingsTest.java
+++ b/hubspot-style-test/src/test/java/com/hubspot/immutables/WireSafeEncodingsTest.java
@@ -1,10 +1,8 @@
 package com.hubspot.immutables;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-
 import com.hubspot.immutables.utils.WireSafeEnum;
+import org.junit.Test;
 
 public class WireSafeEncodingsTest {
 
@@ -12,20 +10,20 @@ public class WireSafeEncodingsTest {
   public void itImplementsBuilderSetProperly() {
     TestImmutable one = TestImmutable.builder()
         .setString("value")
-        .setEnum(TestEnum.ONE)
-        .setOtherEnum(TestEnum.ONE)
+        .setFirstEnum(TestEnum.ONE)
+        .setSecondEnum(TestEnum.ONE)
         .build();
 
     TestImmutable two = TestImmutable.builder()
         .setString("value")
-        .setEnum(WireSafeEnum.of(TestEnum.TWO))
-        .setOtherEnum(WireSafeEnum.of(TestEnum.TWO))
+        .setFirstEnum(WireSafeEnum.of(TestEnum.TWO))
+        .setSecondEnum(WireSafeEnum.of(TestEnum.TWO))
         .build();
 
-    assertThat(one.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
-    assertThat(one.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
-    assertThat(two.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
-    assertThat(two.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+    assertThat(one.getFirstEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(one.getSecondEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(two.getFirstEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+    assertThat(two.getSecondEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
 
     assertThat(one).isNotEqualTo(two);
   }
@@ -34,14 +32,14 @@ public class WireSafeEncodingsTest {
   public void itImplementsWithProperly() {
     TestImmutable one = TestImmutable.builder()
         .setString("value")
-        .setEnum(TestEnum.ONE)
-        .setOtherEnum(TestEnum.ONE)
+        .setFirstEnum(TestEnum.ONE)
+        .setSecondEnum(TestEnum.ONE)
         .build();
 
-    assertThat(one.withEnum(TestEnum.TWO).getEnum())
+    assertThat(one.withFirstEnum(TestEnum.TWO).getFirstEnum())
         .isEqualTo(WireSafeEnum.of(TestEnum.TWO));
 
-    assertThat(one.withOtherEnum(TestEnum.TWO).getOtherEnum())
+    assertThat(one.withSecondEnum(TestEnum.TWO).getSecondEnum())
         .isEqualTo(WireSafeEnum.of(TestEnum.TWO));
   }
 
@@ -49,18 +47,28 @@ public class WireSafeEncodingsTest {
   public void itImplementsFromProperly() {
     TestImmutable one = TestImmutable.builder()
         .setString("value")
-        .setEnum(TestEnum.ONE)
-        .setOtherEnum(TestEnum.TWO)
+        .setFirstEnum(TestEnum.ONE)
+        .setSecondEnum(TestEnum.TWO)
         .build();
 
     TestImmutable two = TestImmutable.builder()
         .from(one)
-        .setOtherEnum(TestEnum.THREE)
+        .setSecondEnum(TestEnum.THREE)
         .build();
 
-    assertThat(two.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
-    assertThat(two.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.THREE));
+    assertThat(two.getFirstEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(two.getSecondEnum()).isEqualTo(WireSafeEnum.of(TestEnum.THREE));
 
     assertThat(one).isNotEqualTo(two);
+  }
+
+  @Test
+  public void itHandlesDefault() {
+    TestImmutable one = TestImmutable.builder()
+        .setString("value")
+        .setSecondEnum(TestEnum.TWO)
+        .build();
+
+    assertThat(one.getFirstEnum()).isEqualTo(WireSafeEnum.of(TestEnum.THREE));
   }
 }

--- a/hubspot-style-test/src/test/java/com/hubspot/immutables/WireSafeEncodingsTest.java
+++ b/hubspot-style-test/src/test/java/com/hubspot/immutables/WireSafeEncodingsTest.java
@@ -1,0 +1,66 @@
+package com.hubspot.immutables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+public class WireSafeEncodingsTest {
+
+  @Test
+  public void itImplementsBuilderSetProperly() {
+    TestImmutable one = TestImmutable.builder()
+        .setString("value")
+        .setEnum(TestEnum.ONE)
+        .setOtherEnum(TestEnum.ONE)
+        .build();
+
+    TestImmutable two = TestImmutable.builder()
+        .setString("value")
+        .setEnum(WireSafeEnum.of(TestEnum.TWO))
+        .setOtherEnum(WireSafeEnum.of(TestEnum.TWO))
+        .build();
+
+    assertThat(one.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(one.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(two.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+    assertThat(two.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+
+    assertThat(one).isNotEqualTo(two);
+  }
+
+  @Test
+  public void itImplementsWithProperly() {
+    TestImmutable one = TestImmutable.builder()
+        .setString("value")
+        .setEnum(TestEnum.ONE)
+        .setOtherEnum(TestEnum.ONE)
+        .build();
+
+    assertThat(one.withEnum(TestEnum.TWO).getEnum())
+        .isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+
+    assertThat(one.withOtherEnum(TestEnum.TWO).getOtherEnum())
+        .isEqualTo(WireSafeEnum.of(TestEnum.TWO));
+  }
+
+  @Test
+  public void itImplementsFromProperly() {
+    TestImmutable one = TestImmutable.builder()
+        .setString("value")
+        .setEnum(TestEnum.ONE)
+        .setOtherEnum(TestEnum.TWO)
+        .build();
+
+    TestImmutable two = TestImmutable.builder()
+        .from(one)
+        .setOtherEnum(TestEnum.THREE)
+        .build();
+
+    assertThat(two.getEnum()).isEqualTo(WireSafeEnum.of(TestEnum.ONE));
+    assertThat(two.getOtherEnum()).isEqualTo(WireSafeEnum.of(TestEnum.THREE));
+
+    assertThat(one).isNotEqualTo(two);
+  }
+}

--- a/hubspot-style/pom.xml
+++ b/hubspot-style/pom.xml
@@ -10,6 +10,10 @@
 
   <artifactId>hubspot-style</artifactId>
 
+  <properties>
+    <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -39,7 +43,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>encode</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.immutables</groupId>
       <artifactId>value</artifactId>

--- a/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
@@ -1,0 +1,56 @@
+package com.hubspot.immutables.encoding;
+
+import org.immutables.encode.Encoding;
+import org.immutables.encode.Encoding.Naming;
+import org.immutables.encode.Encoding.StandardNaming;
+
+import com.hubspot.immutables.utils.WireSafeEnum;
+
+@Encoding
+class WireSafeEnumEncoding<T extends Enum<T>> {
+
+  @Encoding.Impl
+  private WireSafeEnum<T> field;
+
+  @Encoding.Expose
+  @Naming(standard = StandardNaming.GET)
+  WireSafeEnum<T> getValue() {
+    return field;
+  }
+
+  @Encoding.Copy
+  @Naming(standard = StandardNaming.WITH)
+  WireSafeEnum<T> withValue(T value) {
+    return WireSafeEnum.of(value);
+  }
+
+  @Encoding.Init
+  @Encoding.Copy
+  @Naming(standard = StandardNaming.WITH)
+  WireSafeEnum<T> withWireSafeValue(WireSafeEnum<T> value) {
+    return value;
+  }
+
+  @Encoding.Builder
+  static class Builder<T extends Enum<T>> {
+    private WireSafeEnum<T> fieldValue;
+
+    @Encoding.Init
+    @Naming(standard = StandardNaming.INIT)
+    void setValue(T value) {
+      fieldValue = WireSafeEnum.of(value);
+    }
+
+    @Encoding.Init
+    @Encoding.Copy
+    @Naming(standard = StandardNaming.INIT)
+    void setWireSafeValue(WireSafeEnum<T> value) {
+      fieldValue = value;
+    }
+
+    @Encoding.Build
+    WireSafeEnum<T> build() {
+      return fieldValue;
+    }
+  }
+}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
@@ -1,10 +1,9 @@
 package com.hubspot.immutables.encoding;
 
+import com.hubspot.immutables.utils.WireSafeEnum;
 import org.immutables.encode.Encoding;
 import org.immutables.encode.Encoding.Naming;
 import org.immutables.encode.Encoding.StandardNaming;
-
-import com.hubspot.immutables.utils.WireSafeEnum;
 
 @Encoding
 class WireSafeEnumEncoding<T extends Enum<T>> {
@@ -46,6 +45,11 @@ class WireSafeEnumEncoding<T extends Enum<T>> {
     @Naming(standard = StandardNaming.INIT)
     void setWireSafeValue(WireSafeEnum<T> value) {
       fieldValue = value;
+    }
+
+    @Encoding.IsInit
+    boolean getIsSet() {
+      return fieldValue != null;
     }
 
     @Encoding.Build

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>hubspot-style</module>
     <module>immutable-collection-encodings</module>
     <module>immutable-collection-encodings-test</module>
+    <module>hubspot-style-test</module>
   </modules>
 
   <properties>
@@ -26,6 +27,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.hubspot.immutables</groupId>
+        <artifactId>hubspot-style</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.hubspot.immutables</groupId>
         <artifactId>immutables-exceptions</artifactId>


### PR DESCRIPTION
This adds an encoding that allows us to generate convenience setters for WireSafeEnum fields, eg

```java
interface TestImmutableIF {
  WireSafeEnum<SomeEnum> getValue()
}

// generated with methods
TestImmutable withValue(WireSafeEnum<SomeEnum> value);
TestImmutable withValue(SomeEnum value);

// generated builder
TestImmutable.Builder setValue(WireSafeEnum<SomeEnum> value);
TestImmutable.Builder setValue(SomeEnum value);
```

Wanted to get this out here in case we want to try and enable this more globally, especially with the WireSafeEnum validations in chirp.

@zklapow @stevie400 @Xcelled 