### PR TITLE
upgrade basepom, apply prettier formatting

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -1,18 +1,16 @@
 package com.hubspot.immutables.style;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Style.ImplementationVisibility;
 
 /**
  * This style is preferred over {@link HubSpotStyle} because it enforces use of guava's Immutable* collection types. Using these types in immutables is more efficient than using JDK default collections, because immutable collections allow us to make copies of immutables without copying whole collections and avoid copies when calling {@code build()} on immutable builders.
@@ -24,21 +22,22 @@ import com.hubspot.immutables.validation.InvalidImmutableStateException;
  *   <li>The returned values from various getters is actually immutable, and mutations will throw {@link UnsupportedOperationException}</li>
  * </ul>
  */
-@Target({ ElementType.PACKAGE, ElementType.TYPE})
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
 @JsonSerialize
 @Value.Style(
-    get = {"is*", "get*"}, // Detect 'get' and 'is' prefixes in accessor methods
-    init = "set*", // Builder initialization methods will have 'set' prefix
-    typeAbstract = {"Abstract*", "*IF"}, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
-    typeImmutable = "*", // No prefix or suffix for generated immutable type
-    throwForInvalidImmutableState = InvalidImmutableStateException.class,
-    optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
-    forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
-    visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-    passAnnotations = ImmutableInherited.class
+  get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
+  init = "set*", // Builder initialization methods will have 'set' prefix
+  typeAbstract = { "Abstract*", "*IF" }, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
+  typeImmutable = "*", // No prefix or suffix for generated immutable type
+  throwForInvalidImmutableState = InvalidImmutableStateException.class,
+  optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
+  forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
+  visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
+  passAnnotations = ImmutableInherited.class
 )
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled
 @ImmutableMapEncodingEnabled
-public @interface HubSpotImmutableStyle {}
+public @interface HubSpotImmutableStyle {
+}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
@@ -1,29 +1,28 @@
 package com.hubspot.immutables.style;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.hubspot.immutables.validation.InvalidImmutableStateException;
-
-@Target({ ElementType.PACKAGE, ElementType.TYPE})
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
 @JsonSerialize
 @Value.Style(
-    get = {"is*", "get*"}, // Detect 'get' and 'is' prefixes in accessor methods
-    init = "set*", // Builder initialization methods will have 'set' prefix
-    typeAbstract = {"Abstract*", "*IF"}, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
-    typeImmutable = "*", // No prefix or suffix for generated immutable type
-    throwForInvalidImmutableState = InvalidImmutableStateException.class,
-    optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
-    forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
-    visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-    jdkOnly = true,  // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-    passAnnotations = ImmutableInherited.class
+  get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
+  init = "set*", // Builder initialization methods will have 'set' prefix
+  typeAbstract = { "Abstract*", "*IF" }, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
+  typeImmutable = "*", // No prefix or suffix for generated immutable type
+  throwForInvalidImmutableState = InvalidImmutableStateException.class,
+  optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
+  forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
+  visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
+  jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+  passAnnotations = ImmutableInherited.class
 )
-public @interface HubSpotModifiableStyle {}
+public @interface HubSpotModifiableStyle {
+}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
@@ -1,5 +1,7 @@
 package com.hubspot.immutables.style;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,25 +9,23 @@ import java.lang.annotation.Target;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.hubspot.immutables.validation.InvalidImmutableStateException;
-
 /**
  * Consider using {@link HubSpotImmutableStyle} instead.
  */
-@Target({ ElementType.PACKAGE, ElementType.TYPE})
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
 @JsonSerialize
 @Value.Style(
-    get = {"is*", "get*"}, // Detect 'get' and 'is' prefixes in accessor methods
-    init = "set*", // Builder initialization methods will have 'set' prefix
-    typeAbstract = {"Abstract*", "*IF"}, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
-    typeImmutable = "*", // No prefix or suffix for generated immutable type
-    throwForInvalidImmutableState = InvalidImmutableStateException.class,
-    optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
-    forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
-    visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-    jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-    passAnnotations = ImmutableInherited.class
+  get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
+  init = "set*", // Builder initialization methods will have 'set' prefix
+  typeAbstract = { "Abstract*", "*IF" }, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
+  typeImmutable = "*", // No prefix or suffix for generated immutable type
+  throwForInvalidImmutableState = InvalidImmutableStateException.class,
+  optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
+  forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
+  visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
+  jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
+  passAnnotations = ImmutableInherited.class
 )
-public @interface HubSpotStyle {}
+public @interface HubSpotStyle {
+}

--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -53,11 +53,12 @@ import javax.annotation.Nonnull;
  */
 @JsonDeserialize(using = Deserializer.class, keyUsing = KeyDeserializer.class)
 public final class WireSafeEnum<T extends Enum<T>> {
+
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final Map<Class<?>, Map<?, WireSafeEnum<?>>> ENUM_LOOKUP_CACHE =
-      new ConcurrentHashMap<>();
+    new ConcurrentHashMap<>();
   private static final Map<Class<?>, Map<String, WireSafeEnum<?>>> JSON_LOOKUP_CACHE =
-      new ConcurrentHashMap<>();
+    new ConcurrentHashMap<>();
 
   private final Class<T> enumType;
   private final String jsonValue;
@@ -87,8 +88,8 @@ public final class WireSafeEnum<T extends Enum<T>> {
 
   @Nonnull
   public static <T extends Enum<T>> WireSafeEnum<T> fromJson(
-      @Nonnull Class<T> enumType,
-      @Nonnull String jsonValue
+    @Nonnull Class<T> enumType,
+    @Nonnull String jsonValue
   ) {
     return fromJson(enumType, jsonValue, WireSafeEnum::new);
   }
@@ -96,9 +97,9 @@ public final class WireSafeEnum<T extends Enum<T>> {
   @Nonnull
   @SuppressWarnings("unchecked")
   private static <T extends Enum<T>> WireSafeEnum<T> fromJson(
-      @Nonnull Class<T> enumType,
-      @Nonnull String jsonValue,
-      @Nonnull BiFunction<Class<T>, String, WireSafeEnum<T>> fallback
+    @Nonnull Class<T> enumType,
+    @Nonnull String jsonValue,
+    @Nonnull BiFunction<Class<T>, String, WireSafeEnum<T>> fallback
   ) {
     checkNotNull(enumType, "enumType");
     checkNotNull(jsonValue, "jsonValue");
@@ -139,9 +140,9 @@ public final class WireSafeEnum<T extends Enum<T>> {
    */
   @Nonnull
   @Deprecated
-  public <X extends Throwable> T asEnumOrThrow(Supplier<? extends X> exceptionSupplier) throws X {
-    return asEnum()
-        .orElseThrow(exceptionSupplier);
+  public <X extends Throwable> T asEnumOrThrow(Supplier<? extends X> exceptionSupplier)
+    throws X {
+    return asEnum().orElseThrow(exceptionSupplier);
   }
 
   /**
@@ -157,15 +158,19 @@ public final class WireSafeEnum<T extends Enum<T>> {
   }
 
   private IllegalStateException getInvalidValueException() {
-    Collection<WireSafeEnum<?>> wiresafeEnumTypes = JSON_LOOKUP_CACHE.get(enumType).values();
-    String validMembers = Arrays.toString(wiresafeEnumTypes.stream()
-        .map(WireSafeEnum::asString)
-        .distinct()
-        .sorted()
-        .toArray());
+    Collection<WireSafeEnum<?>> wiresafeEnumTypes = JSON_LOOKUP_CACHE
+      .get(enumType)
+      .values();
+    String validMembers = Arrays.toString(
+      wiresafeEnumTypes.stream().map(WireSafeEnum::asString).distinct().sorted().toArray()
+    );
 
-    String message = String.format("Value '%s' is not valid for enum of type '%s'. Valid values are: %s",
-        jsonValue, enumType.getSimpleName(), validMembers);
+    String message = String.format(
+      "Value '%s' is not valid for enum of type '%s'. Valid values are: %s",
+      jsonValue,
+      enumType.getSimpleName(),
+      validMembers
+    );
 
     return new IllegalStateException(message);
   }
@@ -185,9 +190,11 @@ public final class WireSafeEnum<T extends Enum<T>> {
     }
 
     WireSafeEnum<?> that = (WireSafeEnum<?>) o;
-    return Objects.equals(enumType, that.enumType) &&
-        Objects.equals(jsonValue, that.jsonValue) &&
-        Objects.equals(enumValue, that.enumValue);
+    return (
+      Objects.equals(enumType, that.enumType) &&
+      Objects.equals(jsonValue, that.jsonValue) &&
+      Objects.equals(enumValue, that.enumValue)
+    );
   }
 
   @Override
@@ -198,10 +205,10 @@ public final class WireSafeEnum<T extends Enum<T>> {
   @Override
   public String toString() {
     return new StringJoiner(", ", "WireSafeEnum[", "]")
-        .add("enumType=" + enumType)
-        .add("jsonValue='" + jsonValue + "'")
-        .add("enumValue=" + enumValue)
-        .toString();
+      .add("enumType=" + enumType)
+      .add("jsonValue='" + jsonValue + "'")
+      .add("enumValue=" + enumValue)
+      .toString();
   }
 
   private static <T> T checkNotNull(T o, String name) {
@@ -232,12 +239,14 @@ public final class WireSafeEnum<T extends Enum<T>> {
     WireSafeEnum.
      */
     T[] deserializedConstants = MAPPER.convertValue(
-        stringArray,
-        MAPPER.getTypeFactory().constructArrayType(enumType)
+      stringArray,
+      MAPPER.getTypeFactory().constructArrayType(enumType)
     );
 
     Map<T, WireSafeEnum<?>> enumMap = new EnumMap<>(enumType);
-    Map<String, WireSafeEnum<?>> jsonMap = new HashMap<>(mapCapacity(enumConstants.length));
+    Map<String, WireSafeEnum<?>> jsonMap = new HashMap<>(
+      mapCapacity(enumConstants.length)
+    );
 
     for (int i = 0; i < enumConstants.length; i++) {
       T enumValue = enumConstants[i];
@@ -249,10 +258,12 @@ public final class WireSafeEnum<T extends Enum<T>> {
         jsonValue = jsonNode.textValue();
       } else {
         String message = new StringBuilder()
-            .append("Invalid JSON value in enum type: " + enumType.getTypeName() + "\n")
-            .append("Constant " + enumValue.name() + " serialized as: " + jsonNode + "\n")
-            .append("Enums wrapped in WireSafeEnum must serialize to JSON as a non-null string")
-            .toString();
+          .append("Invalid JSON value in enum type: " + enumType.getTypeName() + "\n")
+          .append("Constant " + enumValue.name() + " serialized as: " + jsonNode + "\n")
+          .append(
+            "Enums wrapped in WireSafeEnum must serialize to JSON as a non-null string"
+          )
+          .toString();
         throw new IllegalStateException(message);
       }
 
@@ -280,8 +291,14 @@ public final class WireSafeEnum<T extends Enum<T>> {
     // the class received here may be a subclass of the enum's actual type, which
     // does not have access to the enum's declared constants, so we coerce that type
     // into the supertype that was actually declared
-    if (superType == null || !Enum.class.equals(superType.getSuperclass()) || !superType.equals(enumType.getEnclosingClass())) {
-      throw new IllegalArgumentException("Provided type is not an enum or a direct subclass of an enum");
+    if (
+      superType == null ||
+      !Enum.class.equals(superType.getSuperclass()) ||
+      !superType.equals(enumType.getEnclosingClass())
+    ) {
+      throw new IllegalArgumentException(
+        "Provided type is not an enum or a direct subclass of an enum"
+      );
     }
 
     @SuppressWarnings("unchecked")
@@ -298,18 +315,24 @@ public final class WireSafeEnum<T extends Enum<T>> {
     }
   }
 
-  public static class Deserializer extends JsonDeserializer<WireSafeEnum<?>> implements ContextualDeserializer {
+  public static class Deserializer
+    extends JsonDeserializer<WireSafeEnum<?>>
+    implements ContextualDeserializer {
+
     private static final Map<JavaType, JsonDeserializer<WireSafeEnum<?>>> DESERIALIZER_CACHE =
-        new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
 
     @Override
-    public WireSafeEnum<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public WireSafeEnum<?> deserialize(JsonParser p, DeserializationContext ctxt)
+      throws IOException {
       throw ctxt.mappingException("Expected createContextual to be called");
     }
 
-
     @Override
-    public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
+    public JsonDeserializer<?> createContextual(
+      DeserializationContext ctxt,
+      BeanProperty property
+    ) throws JsonMappingException {
       return deserializerFor(findWireSafeEnumType(ctxt.getContextualType(), ctxt));
     }
 
@@ -317,17 +340,23 @@ public final class WireSafeEnum<T extends Enum<T>> {
       return DESERIALIZER_CACHE.computeIfAbsent(javaType, Deserializer::newDeserializer);
     }
 
-    private static <T extends Enum<T>> JsonDeserializer<WireSafeEnum<?>> newDeserializer(JavaType enumType) {
+    private static <T extends Enum<T>> JsonDeserializer<WireSafeEnum<?>> newDeserializer(
+      JavaType enumType
+    ) {
       return new JsonDeserializer<WireSafeEnum<?>>() {
-
         @Override
-        public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        public WireSafeEnum<T> deserialize(JsonParser p, DeserializationContext ctxt)
+          throws IOException {
           if (p.getCurrentToken() == JsonToken.VALUE_NULL) {
             return null;
           } else if (p.getCurrentToken() == JsonToken.VALUE_STRING) {
             @SuppressWarnings("unchecked")
             Class<T> rawType = (Class<T>) enumType.getRawClass();
-            return WireSafeEnum.fromJson(rawType, p.getText(), (klass, value) -> create(enumType, value, p, ctxt));
+            return WireSafeEnum.fromJson(
+              rawType,
+              p.getText(),
+              (klass, value) -> create(enumType, value, p, ctxt)
+            );
           } else {
             throw ctxt.wrongTokenException(p, JsonToken.VALUE_STRING, null);
           }
@@ -336,42 +365,65 @@ public final class WireSafeEnum<T extends Enum<T>> {
     }
   }
 
-  public static class KeyDeserializer extends com.fasterxml.jackson.databind.KeyDeserializer implements ContextualKeyDeserializer {
+  public static class KeyDeserializer
+    extends com.fasterxml.jackson.databind.KeyDeserializer
+    implements ContextualKeyDeserializer {
+
     private static final Map<JavaType, com.fasterxml.jackson.databind.KeyDeserializer> KEY_DESERIALIZER_CACHE =
-        new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
 
     @Override
-    public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+    public Object deserializeKey(String key, DeserializationContext ctxt)
+      throws IOException {
       throw ctxt.mappingException("Expected createContextual to be called");
     }
 
     @Override
-    public com.fasterxml.jackson.databind.KeyDeserializer createContextual(DeserializationContext ctxt, BeanProperty property) throws JsonMappingException {
-      return keyDeserializerFor(findWireSafeEnumType(ctxt.getContextualType().getKeyType(), ctxt));
+    public com.fasterxml.jackson.databind.KeyDeserializer createContextual(
+      DeserializationContext ctxt,
+      BeanProperty property
+    ) throws JsonMappingException {
+      return keyDeserializerFor(
+        findWireSafeEnumType(ctxt.getContextualType().getKeyType(), ctxt)
+      );
     }
 
-    private static com.fasterxml.jackson.databind.KeyDeserializer keyDeserializerFor(JavaType javaType) {
-      return KEY_DESERIALIZER_CACHE.computeIfAbsent(javaType, KeyDeserializer::newKeyDeserializer);
+    private static com.fasterxml.jackson.databind.KeyDeserializer keyDeserializerFor(
+      JavaType javaType
+    ) {
+      return KEY_DESERIALIZER_CACHE.computeIfAbsent(
+        javaType,
+        KeyDeserializer::newKeyDeserializer
+      );
     }
 
-    private static <T extends Enum<T>> com.fasterxml.jackson.databind.KeyDeserializer newKeyDeserializer(JavaType enumType) {
+    private static <T extends Enum<T>> com.fasterxml.jackson.databind.KeyDeserializer newKeyDeserializer(
+      JavaType enumType
+    ) {
       return new com.fasterxml.jackson.databind.KeyDeserializer() {
-
         @Override
         @SuppressWarnings("unchecked")
-        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+        public Object deserializeKey(String key, DeserializationContext ctxt)
+          throws IOException {
           if (key == null) {
             return null;
           } else {
             Class<T> rawType = (Class<T>) enumType.getRawClass();
-            return WireSafeEnum.fromJson(rawType, key, (klass, value) -> create(enumType, value, ctxt.getParser(), ctxt));
+            return WireSafeEnum.fromJson(
+              rawType,
+              key,
+              (klass, value) -> create(enumType, value, ctxt.getParser(), ctxt)
+            );
           }
         }
       };
     }
   }
 
-  private static JavaType findWireSafeEnumType(JavaType contextualType, DeserializationContext ctxt) throws JsonMappingException {
+  private static JavaType findWireSafeEnumType(
+    JavaType contextualType,
+    DeserializationContext ctxt
+  ) throws JsonMappingException {
     if (contextualType == null || !contextualType.hasRawClass(WireSafeEnum.class)) {
       throw ctxt.mappingException("Can not handle contextualType: " + contextualType);
     } else {
@@ -379,28 +431,41 @@ public final class WireSafeEnum<T extends Enum<T>> {
       if (typeParameters.length != 1) {
         throw ctxt.mappingException("Can not discover enum type for: " + contextualType);
       } else if (!typeParameters[0].isEnumType()) {
-        throw ctxt.mappingException("Can not handle non-enum type: " + typeParameters[0].getRawClass());
+        throw ctxt.mappingException(
+          "Can not handle non-enum type: " + typeParameters[0].getRawClass()
+        );
       } else {
         return typeParameters[0];
       }
     }
   }
 
-  private static <T extends Enum<T>> WireSafeEnum<T> create(JavaType enumType, String jsonValue, JsonParser parser, DeserializationContext ctxt) {
+  private static <T extends Enum<T>> WireSafeEnum<T> create(
+    JavaType enumType,
+    String jsonValue,
+    JsonParser parser,
+    DeserializationContext ctxt
+  ) {
     @SuppressWarnings("unchecked")
     Class<T> rawClass = (Class<T>) enumType.getRawClass();
 
     Optional<T> maybeEnumValue = deserializeValue(enumType, parser, ctxt);
 
     return maybeEnumValue
-        .map(enumValue -> new WireSafeEnum<>(rawClass, jsonValue, enumValue))
-        .orElseGet(() -> new WireSafeEnum<>(rawClass, jsonValue));
+      .map(enumValue -> new WireSafeEnum<>(rawClass, jsonValue, enumValue))
+      .orElseGet(() -> new WireSafeEnum<>(rawClass, jsonValue));
   }
 
   @SuppressWarnings("unchecked")
-  private static <T extends Enum<T>> Optional<T> deserializeValue(JavaType enumType, JsonParser p, DeserializationContext ctxt) {
+  private static <T extends Enum<T>> Optional<T> deserializeValue(
+    JavaType enumType,
+    JsonParser p,
+    DeserializationContext ctxt
+  ) {
     try {
-      JsonDeserializer<?> deserializer = ctxt.findNonContextualValueDeserializer(enumType);
+      JsonDeserializer<?> deserializer = ctxt.findNonContextualValueDeserializer(
+        enumType
+      );
       if (deserializer == null) {
         return Optional.empty();
       }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/ImmutablesTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/ImmutablesTest.java
@@ -3,18 +3,11 @@ package com.hubspot.immutables;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.collect.ImmutableSet;
-import com.hubspot.immutables.model.WidgetGuava;
-import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import com.hubspot.immutables.model.Foo;
 import com.hubspot.immutables.model.FooEgg;
 import com.hubspot.immutables.model.ImmutableWithModifiable;
@@ -24,29 +17,37 @@ import com.hubspot.immutables.model.RosettaSprocket;
 import com.hubspot.immutables.model.RosettaSprocketIF;
 import com.hubspot.immutables.model.Sprocket;
 import com.hubspot.immutables.model.Widget;
+import com.hubspot.immutables.model.WidgetGuava;
 import com.hubspot.immutables.model.Wrapper;
+import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import com.hubspot.rosetta.Rosetta;
+import java.io.IOException;
+import java.math.BigDecimal;
+import org.junit.Test;
 
 public class ImmutablesTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new GuavaModule());
+  private final ObjectMapper objectMapper = new ObjectMapper()
+    .registerModule(new GuavaModule());
 
   @Test
   public void itUsesImmutableEncodings() {
-    WidgetGuava widgetGuava = WidgetGuava.builder()
-        .setAnInt(1)
-        .addSomeOtherVals("test", "test2")
-        .build();
+    WidgetGuava widgetGuava = WidgetGuava
+      .builder()
+      .setAnInt(1)
+      .addSomeOtherVals("test", "test2")
+      .build();
 
     assertThat(widgetGuava.getSomeVals()).isInstanceOf(ImmutableSet.class);
   }
 
   @Test
   public void itGeneratesFromAbstract() {
-    Sprocket sprocket = Sprocket.builder()
-        .setAnInt(1)
-        .setAnOptionalString("isHere")
-        .build();
+    Sprocket sprocket = Sprocket
+      .builder()
+      .setAnInt(1)
+      .setAnOptionalString("isHere")
+      .build();
 
     assertThat(sprocket.getAnInt()).isEqualTo(1);
     assertThat(sprocket.getAnOptionalString()).contains("isHere");
@@ -54,10 +55,7 @@ public class ImmutablesTest {
 
   @Test
   public void itGeneratesFromInterface() {
-    Widget widget = Widget.builder()
-        .setAnInt(1)
-        .setAnOptionalString("isHere")
-        .build();
+    Widget widget = Widget.builder().setAnInt(1).setAnOptionalString("isHere").build();
 
     assertThat(widget.getAnInt()).isEqualTo(1);
     assertThat(widget.getAnOptionalString()).contains("isHere");
@@ -65,14 +63,22 @@ public class ImmutablesTest {
 
   @Test
   public void itThrowsInvalidStateOnValidation() {
-    assertThatThrownBy(() -> Widget.builder().setAnInt(-1).build()).hasMessage("int -1 must be greater than 0").isInstanceOf(InvalidImmutableStateException.class);
-    assertThatThrownBy(() -> Widget.builder().setAnInt(11).build()).hasMessage("int must be less than 10").isInstanceOf(InvalidImmutableStateException.class);
+    assertThatThrownBy(() -> Widget.builder().setAnInt(-1).build())
+      .hasMessage("int -1 must be greater than 0")
+      .isInstanceOf(InvalidImmutableStateException.class);
+    assertThatThrownBy(() -> Widget.builder().setAnInt(11).build())
+      .hasMessage("int must be less than 10")
+      .isInstanceOf(InvalidImmutableStateException.class);
   }
 
   @Test
   public void itDeserializesJson() throws IOException {
-    String inputJson = "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
-    RosettaSprocket rosettaSprocket = objectMapper.readValue(inputJson, RosettaSprocket.class);
+    String inputJson =
+      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
+    RosettaSprocket rosettaSprocket = objectMapper.readValue(
+      inputJson,
+      RosettaSprocket.class
+    );
     assertThat(rosettaSprocket.getId()).isEqualTo(1);
     assertThat(rosettaSprocket.getHubSpotId()).isEqualTo(12);
     assertThat(rosettaSprocket.getName()).isEqualTo("test");
@@ -86,8 +92,11 @@ public class ImmutablesTest {
 
   @Test
   public void itDeserializesRosettaJson() throws IOException {
-    String inputJson = "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
-    RosettaSprocket rosettaSprocket = Rosetta.getMapper().readValue(inputJson, RosettaSprocket.class);
+    String inputJson =
+      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
+    RosettaSprocket rosettaSprocket = Rosetta
+      .getMapper()
+      .readValue(inputJson, RosettaSprocket.class);
     assertThat(rosettaSprocket.getId()).isEqualTo(1);
     assertThat(rosettaSprocket.getHubSpotId()).isEqualTo(12);
     assertThat(rosettaSprocket.getName()).isEqualTo("test");
@@ -101,8 +110,12 @@ public class ImmutablesTest {
 
   @Test
   public void itDeserializesAnInterface() throws IOException {
-    String inputJson = "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
-    RosettaSprocketIF rosettaSprocketIF = objectMapper.readValue(inputJson, RosettaSprocketIF.class);
+    String inputJson =
+      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
+    RosettaSprocketIF rosettaSprocketIF = objectMapper.readValue(
+      inputJson,
+      RosettaSprocketIF.class
+    );
     assertThat(rosettaSprocketIF.getId()).isEqualTo(1);
     assertThat(rosettaSprocketIF.getHubSpotId()).isEqualTo(12);
     assertThat(rosettaSprocketIF.getName()).isEqualTo("test");
@@ -116,8 +129,11 @@ public class ImmutablesTest {
 
   @Test
   public void itDeserializesAnInterfaceFromRosetta() throws IOException {
-    String inputJson = "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
-    RosettaSprocketIF rosettaSprocketIF = Rosetta.getMapper().readValue(inputJson, RosettaSprocketIF.class);
+    String inputJson =
+      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
+    RosettaSprocketIF rosettaSprocketIF = Rosetta
+      .getMapper()
+      .readValue(inputJson, RosettaSprocketIF.class);
     assertThat(rosettaSprocketIF.getId()).isEqualTo(1);
     assertThat(rosettaSprocketIF.getHubSpotId()).isEqualTo(12);
     assertThat(rosettaSprocketIF.getName()).isEqualTo("test");
@@ -144,10 +160,11 @@ public class ImmutablesTest {
 
   @Test
   public void itSupportsNormalization() {
-    NormalizedWidget widget = NormalizedWidget.builder()
-        .setValue(BigDecimal.TEN)
-        .setOptionalValue(BigDecimal.TEN)
-        .build();
+    NormalizedWidget widget = NormalizedWidget
+      .builder()
+      .setValue(BigDecimal.TEN)
+      .setOptionalValue(BigDecimal.TEN)
+      .build();
 
     BigDecimal scaledValue = BigDecimal.TEN.setScale(6, BigDecimal.ROUND_HALF_UP);
 
@@ -158,14 +175,29 @@ public class ImmutablesTest {
   @Test
   public void itParsesAModifiable() throws IOException {
     String inputJson = "{\"names\": [\"Bill\", \"Bob\"], \"description\": \"Foo\"}";
-    assertThatThrownBy(() -> objectMapper.readValue(inputJson, ImmutableWithModifiable.class))
-        .satisfiesAnyOf(
-            t -> assertThat(t).hasMessageStartingWith("Instantiation of [simple type, class com.hubspot.immutables.model.ImmutableWithModifiable] value failed"),
-            t -> assertThat(t).hasMessageStartingWith("Cannot construct instance of `com.hubspot.immutables.model.ImmutableWithModifiable`")
-        )
-        .hasMessageContaining("Cannot build ImmutableWithModifiable, some of required attributes are not set [id]")
-        .isInstanceOf(JsonMappingException.class);
-    ModifiableImmutableWithModifiable modifiable = objectMapper.readValue(inputJson, ModifiableImmutableWithModifiable.class);
+    assertThatThrownBy(() ->
+        objectMapper.readValue(inputJson, ImmutableWithModifiable.class)
+      )
+      .satisfiesAnyOf(
+        t ->
+          assertThat(t)
+            .hasMessageStartingWith(
+              "Instantiation of [simple type, class com.hubspot.immutables.model.ImmutableWithModifiable] value failed"
+            ),
+        t ->
+          assertThat(t)
+            .hasMessageStartingWith(
+              "Cannot construct instance of `com.hubspot.immutables.model.ImmutableWithModifiable`"
+            )
+      )
+      .hasMessageContaining(
+        "Cannot build ImmutableWithModifiable, some of required attributes are not set [id]"
+      )
+      .isInstanceOf(JsonMappingException.class);
+    ModifiableImmutableWithModifiable modifiable = objectMapper.readValue(
+      inputJson,
+      ModifiableImmutableWithModifiable.class
+    );
     assertThatThrownBy(modifiable::toImmutable)
       .hasMessage(
         "ImmutableWithModifiable is not initialized, some of the required attributes are not set [id]"
@@ -181,19 +213,26 @@ public class ImmutablesTest {
   public void itParsesEggPattern() throws IOException {
     String inputJson = "{\"name\": \"EggTest\"}";
     assertThatThrownBy(() -> objectMapper.readValue(inputJson, Foo.class))
-        .satisfiesAnyOf(
-            t -> assertThat(t).hasMessageStartingWith("Instantiation of [simple type, class com.hubspot.immutables.model.Foo] value failed"),
-            t -> assertThat(t).hasMessageStartingWith("Cannot construct instance of `com.hubspot.immutables.model.Foo`")
-        )
-        .hasMessageContaining("Cannot build Foo, some of required attributes are not set [id]")
-        .isInstanceOf(JsonMappingException.class);
+      .satisfiesAnyOf(
+        t ->
+          assertThat(t)
+            .hasMessageStartingWith(
+              "Instantiation of [simple type, class com.hubspot.immutables.model.Foo] value failed"
+            ),
+        t ->
+          assertThat(t)
+            .hasMessageStartingWith(
+              "Cannot construct instance of `com.hubspot.immutables.model.Foo`"
+            )
+      )
+      .hasMessageContaining(
+        "Cannot build Foo, some of required attributes are not set [id]"
+      )
+      .isInstanceOf(JsonMappingException.class);
 
     FooEgg fooEgg = objectMapper.readValue(inputJson, FooEgg.class);
 
-    Foo foo = Foo.builder()
-        .from(fooEgg)
-        .setId(1)
-        .build();
+    Foo foo = Foo.builder().from(fooEgg).setId(1).build();
 
     assertThat(foo.getId()).isEqualTo(1);
     assertThat(foo.getName()).isEqualTo("EggTest");

--- a/hubspot-style/src/test/java/com/hubspot/immutables/InheritedAnnotationTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/InheritedAnnotationTest.java
@@ -2,13 +2,12 @@ package com.hubspot.immutables;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-
 import com.hubspot.immutables.model.annotated.AnnotatedAbstractClass;
 import com.hubspot.immutables.model.annotated.AnnotatedImmutableStyleInterface;
 import com.hubspot.immutables.model.annotated.AnnotatedInterface;
 import com.hubspot.immutables.model.annotated.AnnotatedModifiableInterface;
 import com.hubspot.immutables.model.annotated.InheritedAnnotation;
+import org.junit.Test;
 
 public class InheritedAnnotationTest {
 
@@ -22,14 +21,14 @@ public class InheritedAnnotationTest {
 
   private void checkAnnotations(Class<?> clazz) throws NoSuchMethodException {
     InheritedAnnotation classAnnotation = clazz.getAnnotation(InheritedAnnotation.class);
-    assertThat(classAnnotation)
-      .as("%s is annotated", clazz.getSimpleName())
-      .isNotNull();
+    assertThat(classAnnotation).as("%s is annotated", clazz.getSimpleName()).isNotNull();
     assertThat(classAnnotation.value())
       .as("%s has correct annotation value", clazz.getSimpleName())
       .isEqualTo("type");
 
-    InheritedAnnotation methodAnnotation = clazz.getMethod("getAnnotated").getAnnotation(InheritedAnnotation.class);
+    InheritedAnnotation methodAnnotation = clazz
+      .getMethod("getAnnotated")
+      .getAnnotation(InheritedAnnotation.class);
     assertThat(methodAnnotation)
       .as("%s#getAnnotated() is annotated", clazz.getSimpleName())
       .isNotNull();

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/AbstractNormalizedWidget.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/AbstractNormalizedWidget.java
@@ -1,34 +1,40 @@
 package com.hubspot.immutables.model;
 
-import java.math.BigDecimal;
-import java.util.Optional;
-
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
 public abstract class AbstractNormalizedWidget {
+
   public abstract BigDecimal getValue();
+
   public abstract Optional<BigDecimal> getOptionalValue();
 
   @Value.Check
   public AbstractNormalizedWidget normalize() {
     return isNormalized()
-        ? this
-        : NormalizedWidget.builder()
-          .from(this)
-          .setValue(getValue().setScale(6, BigDecimal.ROUND_HALF_UP))
-          .setOptionalValue(getOptionalValue().map(bigDecimal -> bigDecimal.setScale(6, BigDecimal.ROUND_HALF_UP)))
-          .build();
+      ? this
+      : NormalizedWidget
+        .builder()
+        .from(this)
+        .setValue(getValue().setScale(6, BigDecimal.ROUND_HALF_UP))
+        .setOptionalValue(
+          getOptionalValue()
+            .map(bigDecimal -> bigDecimal.setScale(6, BigDecimal.ROUND_HALF_UP))
+        )
+        .build();
   }
 
   @JsonIgnore
   @Value.Auxiliary
   private boolean isNormalized() {
-    return getValue().scale() == 6
-        && getOptionalValue().map(bigDecimal -> bigDecimal.scale() == 6).orElse(true);
+    return (
+      getValue().scale() == 6 &&
+      getOptionalValue().map(bigDecimal -> bigDecimal.scale() == 6).orElse(true)
+    );
   }
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/AbstractSprocket.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/AbstractSprocket.java
@@ -1,14 +1,14 @@
 package com.hubspot.immutables.model;
 
-import java.util.Optional;
-
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import java.util.Optional;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
 public abstract class AbstractSprocket {
+
   public abstract Optional<String> getAnOptionalString();
+
   public abstract int getAnInt();
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/FooEggIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/FooEggIF.java
@@ -1,10 +1,8 @@
 package com.hubspot.immutables.model;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-public interface FooEggIF extends FooCore {
-}
+public interface FooEggIF extends FooCore {}

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/FooIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/FooIF.java
@@ -1,8 +1,7 @@
 package com.hubspot.immutables.model;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/ImmutableWithModifiableIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/ImmutableWithModifiableIF.java
@@ -1,11 +1,8 @@
 package com.hubspot.immutables.model;
 
-import java.util.List;
-
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotModifiableStyle;
-
+import java.util.List;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @Value.Modifiable

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
@@ -1,12 +1,11 @@
 package com.hubspot.immutables.model;
 
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 import com.hubspot.rosetta.annotations.RosettaProperty;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
@@ -14,8 +13,10 @@ import com.hubspot.rosetta.annotations.RosettaProperty;
 @JsonDeserialize(as = RosettaSprocket.class)
 public interface RosettaSprocketIF {
   int getId();
+
   @RosettaProperty("hubspot_id")
   int getHubSpotId();
+
   String getName();
   String getSomethingWithLongName();
   boolean isBlueSprocket();

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/WidgetGuavaIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/WidgetGuavaIF.java
@@ -1,13 +1,11 @@
 package com.hubspot.immutables.model;
 
-import java.util.Optional;
-import java.util.Set;
-
-import org.immutables.value.Value;
-
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.immutables.style.HubSpotImmutableStyle;
 import com.hubspot.immutables.validation.ImmutableConditions;
+import java.util.Optional;
+import java.util.Set;
+import org.immutables.value.Value;
 
 @HubSpotImmutableStyle
 @Value.Immutable
@@ -20,7 +18,11 @@ public interface WidgetGuavaIF {
 
   @Value.Check
   default void validate() {
-    ImmutableConditions.checkValid(getAnInt() > 0, "int %s must be greater than 0", getAnInt());
+    ImmutableConditions.checkValid(
+      getAnInt() > 0,
+      "int %s must be greater than 0",
+      getAnInt()
+    );
     ImmutableConditions.checkValid(getAnInt() < 10, "int must be less than 10");
   }
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/WidgetIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/WidgetIF.java
@@ -1,11 +1,9 @@
 package com.hubspot.immutables.model;
 
-import java.util.Optional;
-
-import org.immutables.value.Value;
-
-import com.hubspot.immutables.validation.ImmutableConditions;
 import com.hubspot.immutables.style.HubSpotStyle;
+import com.hubspot.immutables.validation.ImmutableConditions;
+import java.util.Optional;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
@@ -15,7 +13,11 @@ public interface WidgetIF {
 
   @Value.Check
   default void validate() {
-    ImmutableConditions.checkValid(getAnInt() > 0, "int %s must be greater than 0", getAnInt());
+    ImmutableConditions.checkValid(
+      getAnInt() > 0,
+      "int %s must be greater than 0",
+      getAnInt()
+    );
     ImmutableConditions.checkValid(getAnInt() < 10, "int must be less than 10");
   }
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/WrappedIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/WrappedIF.java
@@ -1,8 +1,7 @@
 package com.hubspot.immutables.model;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/WrapperIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/WrapperIF.java
@@ -1,9 +1,8 @@
 package com.hubspot.immutables.model;
 
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedAbstractClassIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedAbstractClassIF.java
@@ -1,8 +1,7 @@
 package com.hubspot.immutables.model.annotated;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedImmutableStyleInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedImmutableStyleInterfaceIF.java
@@ -1,8 +1,7 @@
 package com.hubspot.immutables.model.annotated;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotImmutableStyle;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotImmutableStyle

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedInterfaceIF.java
@@ -1,14 +1,12 @@
 package com.hubspot.immutables.model.annotated;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotStyle;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotStyle
 @InheritedAnnotation("type")
 public interface AnnotatedInterfaceIF {
-
   @InheritedAnnotation("method")
   int getAnnotated();
 

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedModifiableInterfaceIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/AnnotatedModifiableInterfaceIF.java
@@ -1,14 +1,12 @@
 package com.hubspot.immutables.model.annotated;
 
-import org.immutables.value.Value;
-
 import com.hubspot.immutables.style.HubSpotModifiableStyle;
+import org.immutables.value.Value;
 
 @Value.Immutable
 @HubSpotModifiableStyle
 @InheritedAnnotation("type")
 public interface AnnotatedModifiableInterfaceIF {
-
   @InheritedAnnotation("method")
   int getAnnotated();
 

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/InheritedAnnotation.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/annotated/InheritedAnnotation.java
@@ -1,15 +1,14 @@
 package com.hubspot.immutables.model.annotated;
 
+import com.hubspot.immutables.style.ImmutableInherited;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.hubspot.immutables.style.ImmutableInherited;
-
 @ImmutableInherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ ElementType.TYPE, ElementType.METHOD })
 public @interface InheritedAnnotation {
   String value();
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -27,10 +27,12 @@ import java.util.stream.Stream;
 import org.junit.Test;
 
 public class WireSafeEnumTest {
+
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   public enum CustomJsonEnum {
-    ABC, DEF;
+    ABC,
+    DEF;
 
     @JsonValue
     public String reversedName() {
@@ -39,7 +41,8 @@ public class WireSafeEnumTest {
   }
 
   public enum NullJsonEnum {
-    ABC, DEF;
+    ABC,
+    DEF;
 
     @JsonValue
     public String jsonName() {
@@ -52,7 +55,8 @@ public class WireSafeEnumTest {
   }
 
   public enum NumericJsonEnum {
-    ABC, DEF;
+    ABC,
+    DEF;
 
     @JsonValue
     public int jsonValue() {
@@ -61,7 +65,8 @@ public class WireSafeEnumTest {
   }
 
   public enum CollidingJsonEnum {
-    ABC, DEF;
+    ABC,
+    DEF;
 
     @JsonValue
     public String jsonName() {
@@ -70,7 +75,8 @@ public class WireSafeEnumTest {
   }
 
   public enum CollidingJsonEnumWithCreator {
-    ABC, DEF;
+    ABC,
+    DEF;
 
     @JsonValue
     public String jsonName() {
@@ -94,8 +100,7 @@ public class WireSafeEnumTest {
       public String getSomething() {
         return "b";
       }
-    }
-    ;
+    };
 
     public String getSomething() {
       return "a";
@@ -104,8 +109,7 @@ public class WireSafeEnumTest {
 
   public enum EnumWithMultipleSerializedForms {
     ABC,
-    DEF,
-    ;
+    DEF;
 
     @JsonCreator
     public static EnumWithMultipleSerializedForms fromString(String s) {
@@ -120,8 +124,7 @@ public class WireSafeEnumTest {
   }
 
   public enum EnumWithNullableJsonCreator {
-    ABC,
-    ;
+    ABC;
 
     @JsonCreator
     public static EnumWithNullableJsonCreator fromString(String s) {
@@ -133,10 +136,12 @@ public class WireSafeEnumTest {
   @JsonSerialize(converter = EnumToStringConverter.class)
   public enum EnumWithConverter {
     ABC("1"),
-    DEF("2"),
-    ;
+    DEF("2");
 
-    private static final Map<String, EnumWithConverter> LOOKUP = Maps.uniqueIndex(Arrays.asList(values()), EnumWithConverter::getValue);
+    private static final Map<String, EnumWithConverter> LOOKUP = Maps.uniqueIndex(
+      Arrays.asList(values()),
+      EnumWithConverter::getValue
+    );
 
     private final String value;
 
@@ -155,17 +160,18 @@ public class WireSafeEnumTest {
 
   // Exceptions from converts are not wrapped in JsonMappingExceptions and therefore we need to test
   // that we also handle these failures
-  public static class StringToEnumConverter implements Converter<String, EnumWithConverter> {
+  public static class StringToEnumConverter
+    implements Converter<String, EnumWithConverter> {
 
     @Override
     public EnumWithConverter convert(String value) {
       return EnumWithConverter
-          .fromString(value)
-          .orElseThrow(() ->
-              new IllegalArgumentException(
-                  "Could not find variant by steroids name with provided value: " + value
-              )
-          );
+        .fromString(value)
+        .orElseThrow(() ->
+          new IllegalArgumentException(
+            "Could not find variant by steroids name with provided value: " + value
+          )
+        );
     }
 
     @Override
@@ -179,7 +185,8 @@ public class WireSafeEnumTest {
     }
   }
 
-  public static class EnumToStringConverter implements Converter<EnumWithConverter, String> {
+  public static class EnumToStringConverter
+    implements Converter<EnumWithConverter, String> {
 
     @Override
     public String convert(EnumWithConverter value) {
@@ -209,8 +216,8 @@ public class WireSafeEnumTest {
   @Test
   public void itParsesNullAsNull() throws IOException {
     WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
-        "null",
-        new TypeReference<WireSafeEnum<RetentionPolicy>>() {}
+      "null",
+      new TypeReference<WireSafeEnum<RetentionPolicy>>() {}
     );
     assertThat(wrapper).isNull();
   }
@@ -219,24 +226,23 @@ public class WireSafeEnumTest {
   public void itDoesntAllowNullJsonValues() {
     Throwable t = catchThrowable(() -> WireSafeEnum.fromJson(NullJsonEnum.class, "ABC"));
     assertThat(t)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("NullJsonEnum")
-        .hasMessageContaining("DEF")
-        .hasMessageContaining("null");
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("NullJsonEnum")
+      .hasMessageContaining("DEF")
+      .hasMessageContaining("null");
   }
 
   @Test
   public void itDoesntAllowNumericJsonValues() {
     Throwable t = catchThrowable(() -> WireSafeEnum.of(NumericJsonEnum.ABC));
     assertThat(t)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("NumericJsonEnum");
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("NumericJsonEnum");
   }
 
   @Test
   public void itBuildsFromEnum() {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.of(RetentionPolicy.SOURCE);
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.of(RetentionPolicy.SOURCE);
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
@@ -244,8 +250,7 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromEnumWithCustomJson() {
-    WireSafeEnum<CustomJsonEnum> wrapper =
-        WireSafeEnum.of(CustomJsonEnum.ABC);
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.of(CustomJsonEnum.ABC);
     assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("CBA");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
@@ -253,8 +258,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromKnownString() {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromJson(RetentionPolicy.class, "SOURCE");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(
+      RetentionPolicy.class,
+      "SOURCE"
+    );
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
@@ -262,8 +269,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromKnownStringWithCustomJson() {
-    WireSafeEnum<CustomJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CustomJsonEnum.class, "CBA");
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CustomJsonEnum.class,
+      "CBA"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("CBA");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
@@ -271,8 +280,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromKnownStringWithCollidingJson() {
-    WireSafeEnum<CollidingJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnum.class, "123");
+    WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnum.class,
+      "123"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("123");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CollidingJsonEnum.ABC));
@@ -280,8 +291,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromKnownStringWithCollidingJsonAndCreator() {
-    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnumWithCreator.class, "123");
+    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnumWithCreator.class,
+      "123"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
     assertThat(wrapper.asString()).isEqualTo("123");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CollidingJsonEnumWithCreator.DEF));
@@ -289,8 +302,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromUnknownString() {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(
+      RetentionPolicy.class,
+      "INVALID"
+    );
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("INVALID");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
@@ -298,8 +313,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromUnknownStringWithCustomJson() {
-    WireSafeEnum<CustomJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CustomJsonEnum.class, "ABC");
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CustomJsonEnum.class,
+      "ABC"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("ABC");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
@@ -307,8 +324,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromUnknownStringWithCollidingJson() {
-    WireSafeEnum<CollidingJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnum.class, "ABC");
+    WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnum.class,
+      "ABC"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
     assertThat(wrapper.asString()).isEqualTo("ABC");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
@@ -316,8 +335,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itBuildsFromUnknownStringWithCollidingJsonAndCreator() {
-    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnumWithCreator.class, "ABC");
+    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnumWithCreator.class,
+      "ABC"
+    );
     assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
     assertThat(wrapper.asString()).isEqualTo("ABC");
     assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
@@ -343,7 +364,10 @@ public class WireSafeEnumTest {
 
   @Test
   public void itSerializesKnownValueAsStringWithCollidingJson() throws IOException {
-    WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(CollidingJsonEnum.class, "123");
+    WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnum.class,
+      "123"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"123\""));
 
     wrapper = WireSafeEnum.of(CollidingJsonEnum.ABC);
@@ -351,9 +375,12 @@ public class WireSafeEnumTest {
   }
 
   @Test
-  public void itSerializesKnownValueAsStringWithCollidingJsonAndCreator() throws IOException {
-    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnumWithCreator.class, "123");
+  public void itSerializesKnownValueAsStringWithCollidingJsonAndCreator()
+    throws IOException {
+    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnumWithCreator.class,
+      "123"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"123\""));
 
     wrapper = WireSafeEnum.of(CollidingJsonEnumWithCreator.ABC);
@@ -362,176 +389,215 @@ public class WireSafeEnumTest {
 
   @Test
   public void itSerializesUnknownValueAsString() throws IOException {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(
+      RetentionPolicy.class,
+      "INVALID"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"INVALID\""));
   }
 
   @Test
   public void itSerializesUnknownValueAsStringWithCustomJson() throws IOException {
-    WireSafeEnum<CustomJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CustomJsonEnum.class, "ABC");
+    WireSafeEnum<CustomJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CustomJsonEnum.class,
+      "ABC"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"ABC\""));
   }
 
   @Test
   public void itSerializesUnknownValueAsStringWithCollidingJson() throws IOException {
-    WireSafeEnum<CollidingJsonEnum> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnum.class, "ABC");
+    WireSafeEnum<CollidingJsonEnum> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnum.class,
+      "ABC"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"ABC\""));
   }
 
   @Test
-  public void itSerializesUnknownValueAsStringWithCollidingJsonAndCreator() throws IOException {
-    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper =
-        WireSafeEnum.fromJson(CollidingJsonEnumWithCreator.class, "ABC");
+  public void itSerializesUnknownValueAsStringWithCollidingJsonAndCreator()
+    throws IOException {
+    WireSafeEnum<CollidingJsonEnumWithCreator> wrapper = WireSafeEnum.fromJson(
+      CollidingJsonEnumWithCreator.class,
+      "ABC"
+    );
     writeToJson(wrapper).forEach(s -> assertThat(s).isEqualTo("\"ABC\""));
   }
 
   @Test
   public void itDeserializesFromKnownString() throws IOException {
-    readFromJson("\"SOURCE\"", new TypeReference<WireSafeEnum<RetentionPolicy>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
-      assertThat(wrapper.asString()).isEqualTo("SOURCE");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
-    });
+    readFromJson("\"SOURCE\"", new TypeReference<WireSafeEnum<RetentionPolicy>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+        assertThat(wrapper.asString()).isEqualTo("SOURCE");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.of(RetentionPolicy.SOURCE));
+      });
   }
 
   @Test
   public void itDeserializesFromKnownStringWithCustomJson() throws IOException {
-    readFromJson("\"CBA\"", new TypeReference<WireSafeEnum<CustomJsonEnum>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
-      assertThat(wrapper.asString()).isEqualTo("CBA");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
-    });
+    readFromJson("\"CBA\"", new TypeReference<WireSafeEnum<CustomJsonEnum>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+        assertThat(wrapper.asString()).isEqualTo("CBA");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CustomJsonEnum.ABC));
+      });
   }
 
   @Test
   public void itDeserializesFromKnownStringWithCollidingJson() throws IOException {
-    readFromJson("\"123\"", new TypeReference<WireSafeEnum<CollidingJsonEnum>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
-      assertThat(wrapper.asString()).isEqualTo("123");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CollidingJsonEnum.ABC));
-    });
+    readFromJson("\"123\"", new TypeReference<WireSafeEnum<CollidingJsonEnum>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
+        assertThat(wrapper.asString()).isEqualTo("123");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CollidingJsonEnum.ABC));
+      });
   }
 
   @Test
-  public void itDeserializesFromKnownStringWithCollidingJsonAndCreator() throws IOException {
-    readFromJson("\"123\"", new TypeReference<WireSafeEnum<CollidingJsonEnumWithCreator>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
-      assertThat(wrapper.asString()).isEqualTo("123");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.of(CollidingJsonEnumWithCreator.DEF));
-    });
+  public void itDeserializesFromKnownStringWithCollidingJsonAndCreator()
+    throws IOException {
+    readFromJson(
+      "\"123\"",
+      new TypeReference<WireSafeEnum<CollidingJsonEnumWithCreator>>() {}
+    )
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
+        assertThat(wrapper.asString()).isEqualTo("123");
+        assertThat(wrapper.asEnum())
+          .isEqualTo(Optional.of(CollidingJsonEnumWithCreator.DEF));
+      });
   }
 
   @Test
   public void itDeserializesFromUnknownString() throws IOException {
-    readFromJson("\"INVALID\"", new TypeReference<WireSafeEnum<RetentionPolicy>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
-      assertThat(wrapper.asString()).isEqualTo("INVALID");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
-    });
+    readFromJson("\"INVALID\"", new TypeReference<WireSafeEnum<RetentionPolicy>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
+        assertThat(wrapper.asString()).isEqualTo("INVALID");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+      });
   }
 
   @Test
   public void itDeserializesFromUnknownStringWithCustomJson() throws IOException {
-    readFromJson("\"ABC\"", new TypeReference<WireSafeEnum<CustomJsonEnum>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
-      assertThat(wrapper.asString()).isEqualTo("ABC");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
-    });
+    readFromJson("\"ABC\"", new TypeReference<WireSafeEnum<CustomJsonEnum>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CustomJsonEnum.class);
+        assertThat(wrapper.asString()).isEqualTo("ABC");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+      });
   }
 
   @Test
   public void itDeserializesFromUnknownStringWithCollidingJson() throws IOException {
-    readFromJson("\"ABC\"", new TypeReference<WireSafeEnum<CollidingJsonEnum>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
-      assertThat(wrapper.asString()).isEqualTo("ABC");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
-    });
+    readFromJson("\"ABC\"", new TypeReference<WireSafeEnum<CollidingJsonEnum>>() {})
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnum.class);
+        assertThat(wrapper.asString()).isEqualTo("ABC");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+      });
   }
 
   @Test
-  public void itDeserializesFromUnknownStringWithCollidingJsonAndCreator() throws IOException {
-    readFromJson("\"ABC\"", new TypeReference<WireSafeEnum<CollidingJsonEnumWithCreator>>() {}).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
-      assertThat(wrapper.asString()).isEqualTo("ABC");
-      assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
-    });
+  public void itDeserializesFromUnknownStringWithCollidingJsonAndCreator()
+    throws IOException {
+    readFromJson(
+      "\"ABC\"",
+      new TypeReference<WireSafeEnum<CollidingJsonEnumWithCreator>>() {}
+    )
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(CollidingJsonEnumWithCreator.class);
+        assertThat(wrapper.asString()).isEqualTo("ABC");
+        assertThat(wrapper.asEnum()).isEqualTo(Optional.empty());
+      });
   }
 
   @Test
   public void itThrowsForValueFromUnknownString() {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(
+      RetentionPolicy.class,
+      "INVALID"
+    );
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("INVALID");
 
     assertThatThrownBy(wrapper::asEnumOrThrow)
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Value 'INVALID' is not valid for enum of type 'RetentionPolicy'. Valid values are: [CLASS, RUNTIME, SOURCE]");
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage(
+        "Value 'INVALID' is not valid for enum of type 'RetentionPolicy'. Valid values are: [CLASS, RUNTIME, SOURCE]"
+      );
   }
 
   @Test
   public void itDoesNotThrowForValueFromKnownString() {
-    WireSafeEnum<RetentionPolicy> wrapper =
-        WireSafeEnum.fromJson(RetentionPolicy.class, "SOURCE");
+    WireSafeEnum<RetentionPolicy> wrapper = WireSafeEnum.fromJson(
+      RetentionPolicy.class,
+      "SOURCE"
+    );
     assertThat(wrapper.enumType()).isEqualTo(RetentionPolicy.class);
     assertThat(wrapper.asString()).isEqualTo("SOURCE");
 
-    assertThat(wrapper.asEnumOrThrow())
-        .isEqualTo(RetentionPolicy.SOURCE);
+    assertThat(wrapper.asEnumOrThrow()).isEqualTo(RetentionPolicy.SOURCE);
   }
 
   @Test
   public void itDelegatesToJsonCreatorIfNotCached() throws Exception {
-    TypeReference<WireSafeEnum<EnumWithMultipleSerializedForms>> type = new TypeReference<WireSafeEnum<EnumWithMultipleSerializedForms>>() {};
+    TypeReference<WireSafeEnum<EnumWithMultipleSerializedForms>> type =
+      new TypeReference<WireSafeEnum<EnumWithMultipleSerializedForms>>() {};
 
-    readFromJson("\"ABC\"", type).forEach(wrapper ->
+    readFromJson("\"ABC\"", type)
+      .forEach(wrapper ->
         assertCorrectEnum(wrapper, "ABC", EnumWithMultipleSerializedForms.ABC)
-    );
-    readFromJson("\"abc\"", type).forEach(wrapper ->
+      );
+    readFromJson("\"abc\"", type)
+      .forEach(wrapper ->
         assertCorrectEnum(wrapper, "abc", EnumWithMultipleSerializedForms.ABC)
-    );
-    readFromJson("\"def\"", type).forEach(wrapper ->
+      );
+    readFromJson("\"def\"", type)
+      .forEach(wrapper ->
         assertCorrectEnum(wrapper, "def", EnumWithMultipleSerializedForms.DEF)
-    );
-    readFromJson("\"xyz\"", type).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(EnumWithMultipleSerializedForms.class);
-      assertThat(wrapper.asString()).isEqualTo("xyz");
-      assertThat(wrapper.asEnum()).isEmpty();
-    });
+      );
+    readFromJson("\"xyz\"", type)
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(EnumWithMultipleSerializedForms.class);
+        assertThat(wrapper.asString()).isEqualTo("xyz");
+        assertThat(wrapper.asEnum()).isEmpty();
+      });
   }
 
   @Test
   public void itHandlesNullFromJsonCreator() throws Exception {
-    TypeReference<WireSafeEnum<EnumWithNullableJsonCreator>> type = new TypeReference<WireSafeEnum<EnumWithNullableJsonCreator>>() {};
+    TypeReference<WireSafeEnum<EnumWithNullableJsonCreator>> type =
+      new TypeReference<WireSafeEnum<EnumWithNullableJsonCreator>>() {};
 
-    readFromJson("\"ABC\"", type).forEach(wrapper ->
+    readFromJson("\"ABC\"", type)
+      .forEach(wrapper ->
         assertCorrectEnum(wrapper, "ABC", EnumWithNullableJsonCreator.ABC)
-    );
-    readFromJson("\"xyz\"", type).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(EnumWithNullableJsonCreator.class);
-      assertThat(wrapper.asString()).isEqualTo("xyz");
-      assertThat(wrapper.asEnum()).isEmpty();
-    });
+      );
+    readFromJson("\"xyz\"", type)
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(EnumWithNullableJsonCreator.class);
+        assertThat(wrapper.asString()).isEqualTo("xyz");
+        assertThat(wrapper.asEnum()).isEmpty();
+      });
   }
 
   @Test
   public void itHandlesEnumsWithConverters() throws Exception {
-    TypeReference<WireSafeEnum<EnumWithConverter>> type = new TypeReference<WireSafeEnum<EnumWithConverter>>() {};
+    TypeReference<WireSafeEnum<EnumWithConverter>> type =
+      new TypeReference<WireSafeEnum<EnumWithConverter>>() {};
 
-    readFromJson("\"1\"", type).forEach(wrapper ->
-        assertCorrectEnum(wrapper, "1", EnumWithConverter.ABC)
-    );
-    readFromJson("\"2\"", type).forEach(wrapper ->
-        assertCorrectEnum(wrapper, "2", EnumWithConverter.DEF)
-    );
-    readFromJson("\"3\"", type).forEach(wrapper -> {
-      assertThat(wrapper.enumType()).isEqualTo(EnumWithConverter.class);
-      assertThat(wrapper.asString()).isEqualTo("3");
-      assertThat(wrapper.asEnum()).isEmpty();
-    });
+    readFromJson("\"1\"", type)
+      .forEach(wrapper -> assertCorrectEnum(wrapper, "1", EnumWithConverter.ABC));
+    readFromJson("\"2\"", type)
+      .forEach(wrapper -> assertCorrectEnum(wrapper, "2", EnumWithConverter.DEF));
+    readFromJson("\"3\"", type)
+      .forEach(wrapper -> {
+        assertThat(wrapper.enumType()).isEqualTo(EnumWithConverter.class);
+        assertThat(wrapper.asString()).isEqualTo("3");
+        assertThat(wrapper.asEnum()).isEmpty();
+      });
   }
 
   @Test
@@ -541,8 +607,8 @@ public class WireSafeEnumTest {
     original.put(WireSafeEnum.fromJson(RetentionPolicy.class, "INVALID"), 456);
 
     Map<WireSafeEnum<RetentionPolicy>, Integer> parsed = MAPPER.readValue(
-        MAPPER.writeValueAsString(original),
-        new TypeReference<Map<WireSafeEnum<RetentionPolicy>, Integer>>() {}
+      MAPPER.writeValueAsString(original),
+      new TypeReference<Map<WireSafeEnum<RetentionPolicy>, Integer>>() {}
     );
 
     assertThat(parsed).isEqualTo(original);
@@ -552,23 +618,38 @@ public class WireSafeEnumTest {
     Map<WireSafeEnum<?>, Integer> map = Collections.singletonMap(wireSafeEnum, 123);
     String mapKey = Iterators.getOnlyElement(MAPPER.valueToTree(map).fieldNames());
 
-    return Stream.of(MAPPER.writeValueAsString(wireSafeEnum), MAPPER.writeValueAsString(mapKey));
+    return Stream.of(
+      MAPPER.writeValueAsString(wireSafeEnum),
+      MAPPER.writeValueAsString(mapKey)
+    );
   }
 
-  private <T extends Enum<T>> Stream<WireSafeEnum<T>> readFromJson(String json, TypeReference<WireSafeEnum<T>> typeReference) throws IOException {
-    Map<WireSafeEnum<T>, Integer> map = MAPPER.readValue("{" + json + ": 123}", MAPPER.getTypeFactory().constructMapType(
-        HashMap.class,
-        MAPPER.constructType(typeReference.getType()),
-        MAPPER.constructType(Integer.class))
+  private <T extends Enum<T>> Stream<WireSafeEnum<T>> readFromJson(
+    String json,
+    TypeReference<WireSafeEnum<T>> typeReference
+  ) throws IOException {
+    Map<WireSafeEnum<T>, Integer> map = MAPPER.readValue(
+      "{" + json + ": 123}",
+      MAPPER
+        .getTypeFactory()
+        .constructMapType(
+          HashMap.class,
+          MAPPER.constructType(typeReference.getType()),
+          MAPPER.constructType(Integer.class)
+        )
     );
 
     return Stream.of(
-        MAPPER.readValue(json, typeReference),
-        Iterables.getOnlyElement(map.keySet())
+      MAPPER.readValue(json, typeReference),
+      Iterables.getOnlyElement(map.keySet())
     );
   }
 
-  private <T extends Enum<T>> void assertCorrectEnum(WireSafeEnum<?> wrapper, String stringValue, T enumValue) {
+  private <T extends Enum<T>> void assertCorrectEnum(
+    WireSafeEnum<?> wrapper,
+    String stringValue,
+    T enumValue
+  ) {
     assertThat(wrapper.enumType()).isEqualTo(enumValue.getClass());
     assertThat(wrapper.asString()).isEqualTo(stringValue);
     assertThat(wrapper.asEnum().isPresent()).isTrue();

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutable.collection.encoding.test;
 
 import java.util.List;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithDefaultIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithDefaultIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutable.collection.encoding.test;
 
 import com.google.common.collect.ImmutableList;
-
 import org.immutables.value.Value.Default;
 import org.immutables.value.Value.Immutable;
 

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestMapIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestMapIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutable.collection.encoding.test;
 
 import java.util.Map;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestSetIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestSetIF.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutable.collection.encoding.test;
 
 import java.util.Set;
-
 import org.immutables.value.Value.Immutable;
 import org.immutables.value.Value.Parameter;
 

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestStyle.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestStyle.java
@@ -1,25 +1,24 @@
 package com.hubspot.immutable.collection.encoding.test;
 
+import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
+import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
+import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import org.immutables.value.Value;
 import org.immutables.value.Value.Style.ImplementationVisibility;
 
-import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
-import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
-import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
-
-@Target({ ElementType.PACKAGE, ElementType.TYPE})
+@Target({ ElementType.PACKAGE, ElementType.TYPE })
 @Retention(RetentionPolicy.CLASS) // Make it class retention for incremental compilation
 @Value.Style(
-    get = {"is*", "get*"}, // Detect 'get' and 'is' prefixes in accessor methods
-    init = "set*", // Builder initialization methods will have 'set' prefix
-    typeAbstract = {"Abstract*", "*IF"}, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
-    typeImmutable = "*", // No prefix or suffix for generated immutable type
-    visibility = ImplementationVisibility.SAME)
+  get = { "is*", "get*" }, // Detect 'get' and 'is' prefixes in accessor methods
+  init = "set*", // Builder initialization methods will have 'set' prefix
+  typeAbstract = { "Abstract*", "*IF" }, // 'Abstract' prefix, and 'IF' suffix, will be detected and trimmed
+  typeImmutable = "*", // No prefix or suffix for generated immutable type
+  visibility = ImplementationVisibility.SAME
+)
 @ImmutableMapEncodingEnabled
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
@@ -2,14 +2,12 @@ package com.hubspot.immutable.collection.encoding.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
 
 public class ImmutableListEncodingTest {
 
@@ -17,9 +15,7 @@ public class ImmutableListEncodingTest {
   public void itDoesNotCopyInputImmutableList() {
     List<String> strings = ImmutableList.of("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .setStrings(strings)
-        .build();
+    TestList test = TestList.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -28,9 +24,7 @@ public class ImmutableListEncodingTest {
   public void itDoesNotCopyInputImmutableSet() {
     ImmutableSet<String> strings = ImmutableSet.of("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .setStrings(strings)
-        .build();
+    TestList test = TestList.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings.asList());
   }
@@ -39,9 +33,7 @@ public class ImmutableListEncodingTest {
   public void itDoesNotCopyAddedImmutableList() {
     List<String> strings = ImmutableList.of("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .addAllStrings(strings)
-        .build();
+    TestList test = TestList.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -50,9 +42,7 @@ public class ImmutableListEncodingTest {
   public void itDoesCopyList() {
     List<String> strings = Lists.newArrayList("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .setStrings(strings)
-        .build();
+    TestList test = TestList.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isInstanceOf(ImmutableList.class);
     assertThat(test.getStrings()).isNotSameAs(strings);
@@ -62,10 +52,7 @@ public class ImmutableListEncodingTest {
   public void itCanExpandInputImmutableList() {
     List<String> strings = ImmutableList.of("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .setStrings(strings)
-        .addStrings("another")
-        .build();
+    TestList test = TestList.builder().setStrings(strings).addStrings("another").build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test", "another");
   }
@@ -74,9 +61,7 @@ public class ImmutableListEncodingTest {
   public void itCanExpandFromEmpty() {
     List<String> strings = Lists.newArrayList("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .addAllStrings(strings)
-        .build();
+    TestList test = TestList.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
@@ -85,27 +70,21 @@ public class ImmutableListEncodingTest {
   public void itCanAcceptIterable() {
     Iterable<String> strings = Lists.newArrayList("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .addAllStrings(strings)
-        .build();
+    TestList test = TestList.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
 
   @Test
   public void itCanAcceptVarargs() {
-    TestList test = TestList.builder()
-        .addStrings("testing", "this is a test")
-        .build();
+    TestList test = TestList.builder().addStrings("testing", "this is a test").build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
 
   @Test
   public void itCanAcceptVarargsWith() {
-    TestList test = TestList.builder()
-        .build()
-        .withStrings("testing", "this is a test");
+    TestList test = TestList.builder().build().withStrings("testing", "this is a test");
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
@@ -115,22 +94,21 @@ public class ImmutableListEncodingTest {
     List<String> strings = ImmutableList.of("testing", "this is a test");
     List<String> moreStrings = ImmutableList.of("more1", "more2");
 
-    TestList test = TestList.builder()
-        .setStrings(strings)
-        .addAllStrings(moreStrings)
-        .build();
+    TestList test = TestList
+      .builder()
+      .setStrings(strings)
+      .addAllStrings(moreStrings)
+      .build();
 
-    assertThat(test.getStrings()).containsExactly("testing", "this is a test", "more1", "more2");
+    assertThat(test.getStrings())
+      .containsExactly("testing", "this is a test", "more1", "more2");
   }
-
 
   @Test
   public void itDoesNotCopyInputImmutableListUsingWith() {
     List<String> strings = ImmutableList.of("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .build()
-        .withStrings(strings);
+    TestList test = TestList.builder().build().withStrings(strings);
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -139,9 +117,7 @@ public class ImmutableListEncodingTest {
   public void itDoesNotCopyInputListUsingWith() {
     List<String> strings = Lists.newArrayList("testing", "this is a test");
 
-    TestList test = TestList.builder()
-        .build()
-        .withStrings(strings);
+    TestList test = TestList.builder().build().withStrings(strings);
 
     assertThat(test.getStrings()).isInstanceOf(ImmutableList.class);
     assertThat(test.getStrings()).containsExactlyElementsOf(strings);
@@ -153,5 +129,4 @@ public class ImmutableListEncodingTest {
 
     assertThat(test.getStrings()).containsExactly("testing");
   }
-
 }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableMapEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableMapEncodingTest.java
@@ -2,22 +2,23 @@ package com.hubspot.immutable.collection.encoding.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import java.util.Map;
+import org.junit.Test;
 
 public class ImmutableMapEncodingTest {
 
   @Test
   public void itDoesNotCopyInputImmutableMap() {
-    Map<String, String> strings = ImmutableMap.of("testing", "this is a test", "test2", "other test");
+    Map<String, String> strings = ImmutableMap.of(
+      "testing",
+      "this is a test",
+      "test2",
+      "other test"
+    );
 
-    TestMap test = TestMap.builder()
-        .setStrings(strings)
-        .build();
+    TestMap test = TestMap.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -26,9 +27,7 @@ public class ImmutableMapEncodingTest {
   public void itDoesNotCopyAddedImmutableMap() {
     Map<String, String> strings = ImmutableMap.of("testing", "this is a test");
 
-    TestMap test = TestMap.builder()
-        .putAllStrings(strings)
-        .build();
+    TestMap test = TestMap.builder().putAllStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -39,9 +38,7 @@ public class ImmutableMapEncodingTest {
     strings.put("Test", "test");
     strings.put("test2", "test2");
 
-    TestMap test = TestMap.builder()
-        .setStrings(strings)
-        .build();
+    TestMap test = TestMap.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isInstanceOf(ImmutableMap.class);
     assertThat(test.getStrings()).isNotSameAs(strings);
@@ -51,10 +48,11 @@ public class ImmutableMapEncodingTest {
   public void itCanExpandInputImmutableMap() {
     Map<String, String> strings = ImmutableMap.of("testing", "this is a test");
 
-    TestMap test = TestMap.builder()
-        .setStrings(strings)
-        .putStrings("key", "another")
-        .build();
+    TestMap test = TestMap
+      .builder()
+      .setStrings(strings)
+      .putStrings("key", "another")
+      .build();
 
     assertThat(test.getStrings()).containsKeys("testing", "key");
     assertThat(test.getStrings()).containsValues("this is a test", "another");
@@ -65,9 +63,7 @@ public class ImmutableMapEncodingTest {
     Map<String, String> strings = Maps.newHashMap();
     strings.put("testing", "this is a test");
 
-    TestMap test = TestMap.builder()
-        .putAllStrings(strings)
-        .build();
+    TestMap test = TestMap.builder().putAllStrings(strings).build();
 
     assertThat(test.getStrings().size()).isEqualTo(1);
   }
@@ -77,23 +73,21 @@ public class ImmutableMapEncodingTest {
     Map<String, String> strings = ImmutableMap.of("testing", "this is a test");
     Map<String, String> moreStrings = ImmutableMap.of("more1", "more2");
 
-    TestMap test = TestMap.builder()
-        .setStrings(strings)
-        .putAllStrings(moreStrings)
-        .build();
+    TestMap test = TestMap
+      .builder()
+      .setStrings(strings)
+      .putAllStrings(moreStrings)
+      .build();
 
     assertThat(test.getStrings()).containsKeys("testing", "more1");
     assertThat(test.getStrings()).containsValues("this is a test", "more2");
   }
 
-
   @Test
   public void itDoesNotCopyInputImmutableMapUsingWith() {
     Map<String, String> strings = ImmutableMap.of("testing", "this is a test");
 
-    TestMap test = TestMap.builder()
-        .build()
-        .withStrings(strings);
+    TestMap test = TestMap.builder().build().withStrings(strings);
 
     assertThat(test.getStrings()).isSameAs(strings);
   }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
@@ -2,14 +2,12 @@ package com.hubspot.immutable.collection.encoding.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
-import java.util.Set;
-
-import org.junit.Test;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Test;
 
 public class ImmutableSetEncodingTest {
 
@@ -17,9 +15,7 @@ public class ImmutableSetEncodingTest {
   public void itDoesNotCopyInputImmutableSet() {
     Set<String> strings = ImmutableSet.of("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .setStrings(strings)
-        .build();
+    TestSet test = TestSet.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -28,9 +24,7 @@ public class ImmutableSetEncodingTest {
   public void itDoesNotCopyAddedImmutableSet() {
     Set<String> strings = ImmutableSet.of("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .addAllStrings(strings)
-        .build();
+    TestSet test = TestSet.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -39,9 +33,7 @@ public class ImmutableSetEncodingTest {
   public void itDoesCopySet() {
     Set<String> strings = Sets.newHashSet("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .setStrings(strings)
-        .build();
+    TestSet test = TestSet.builder().setStrings(strings).build();
 
     assertThat(test.getStrings()).isInstanceOf(ImmutableSet.class);
     assertThat(test.getStrings()).isNotSameAs(strings);
@@ -51,21 +43,17 @@ public class ImmutableSetEncodingTest {
   public void itCanExpandInputImmutableSet() {
     Set<String> strings = ImmutableSet.of("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .setStrings(strings)
-        .addStrings("another")
-        .build();
+    TestSet test = TestSet.builder().setStrings(strings).addStrings("another").build();
 
-    assertThat(test.getStrings()).containsExactlyInAnyOrder("testing", "this is a test", "another");
+    assertThat(test.getStrings())
+      .containsExactlyInAnyOrder("testing", "this is a test", "another");
   }
 
   @Test
   public void itCanExpandFromEmpty() {
     Set<String> strings = Sets.newHashSet("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .addAllStrings(strings)
-        .build();
+    TestSet test = TestSet.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).containsExactlyInAnyOrder("testing", "this is a test");
   }
@@ -74,27 +62,21 @@ public class ImmutableSetEncodingTest {
   public void itCanAcceptIterable() {
     Iterable<String> strings = Lists.newArrayList("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .addAllStrings(strings)
-        .build();
+    TestSet test = TestSet.builder().addAllStrings(strings).build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
 
   @Test
   public void itCanAcceptVarargs() {
-    TestSet test = TestSet.builder()
-        .addStrings("testing", "this is a test")
-        .build();
+    TestSet test = TestSet.builder().addStrings("testing", "this is a test").build();
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
 
   @Test
   public void itCanAcceptVarargsWith() {
-    TestSet test = TestSet.builder()
-        .build()
-        .withStrings("testing", "this is a test");
+    TestSet test = TestSet.builder().build().withStrings("testing", "this is a test");
 
     assertThat(test.getStrings()).containsExactly("testing", "this is a test");
   }
@@ -104,22 +86,21 @@ public class ImmutableSetEncodingTest {
     Set<String> strings = ImmutableSet.of("testing", "this is a test");
     Set<String> moreStrings = ImmutableSet.of("more1", "more2");
 
-    TestSet test = TestSet.builder()
-        .setStrings(strings)
-        .addAllStrings(moreStrings)
-        .build();
+    TestSet test = TestSet
+      .builder()
+      .setStrings(strings)
+      .addAllStrings(moreStrings)
+      .build();
 
-    assertThat(test.getStrings()).containsExactlyInAnyOrder("testing", "this is a test", "more1", "more2");
+    assertThat(test.getStrings())
+      .containsExactlyInAnyOrder("testing", "this is a test", "more1", "more2");
   }
-
 
   @Test
   public void itDoesNotCopyInputImmutableSetUsingWith() {
     Set<String> strings = ImmutableSet.of("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .build()
-        .withStrings(strings);
+    TestSet test = TestSet.builder().build().withStrings(strings);
 
     assertThat(test.getStrings()).isSameAs(strings);
   }
@@ -128,9 +109,7 @@ public class ImmutableSetEncodingTest {
   public void itDoesNotCopyInputSetUsingWith() {
     Set<String> strings = Sets.newHashSet("testing", "this is a test");
 
-    TestSet test = TestSet.builder()
-        .build()
-        .withStrings(strings);
+    TestSet test = TestSet.builder().build().withStrings(strings);
 
     assertThat(test.getStrings()).isInstanceOf(ImmutableSet.class);
     assertThat(test.getStrings()).containsAll(strings);
@@ -142,5 +121,4 @@ public class ImmutableSetEncodingTest {
 
     assertThat(test.getStrings()).containsExactly("testing");
   }
-
 }

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableListEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableListEncoding.java
@@ -1,14 +1,12 @@
 package com.hubspot.immutable.collection.encoding;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
 import java.util.Collection;
 import java.util.List;
-
 import org.immutables.encode.Encoding;
 import org.immutables.encode.Encoding.Naming;
 import org.immutables.encode.Encoding.StandardNaming;
-
-import com.google.common.collect.ImmutableCollection;
-import com.google.common.collect.ImmutableList;
 
 @Encoding
 public class ImmutableListEncoding<T> {
@@ -56,7 +54,9 @@ public class ImmutableListEncoding<T> {
       if (builder != null) {
         builder.add(element);
       } else if (list != null) {
-        builder = ImmutableList.<T>builderWithExpectedSize(list.size() + 1)
+        builder =
+          ImmutableList
+            .<T>builderWithExpectedSize(list.size() + 1)
             .addAll(list)
             .add(element);
 
@@ -78,7 +78,9 @@ public class ImmutableListEncoding<T> {
           additionalSize = ((Collection<? extends T>) elements).size();
         }
 
-        builder = ImmutableList.<T>builderWithExpectedSize(list.size() + additionalSize)
+        builder =
+          ImmutableList
+            .<T>builderWithExpectedSize(list.size() + additionalSize)
             .addAll(list)
             .addAll(elements);
 
@@ -87,7 +89,10 @@ public class ImmutableListEncoding<T> {
         if (elements instanceof ImmutableCollection) {
           set(elements);
         } else if (elements instanceof Collection) {
-          builder = ImmutableList.builderWithExpectedSize(((Collection<? extends T>) elements).size());
+          builder =
+            ImmutableList.builderWithExpectedSize(
+              ((Collection<? extends T>) elements).size()
+            );
           builder.addAll(elements);
         } else {
           builder = ImmutableList.builder();

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableMapEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableMapEncoding.java
@@ -1,12 +1,10 @@
 package com.hubspot.immutable.collection.encoding;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-
 import org.immutables.encode.Encoding;
 import org.immutables.encode.Encoding.Naming;
 import org.immutables.encode.Encoding.StandardNaming;
-
-import com.google.common.collect.ImmutableMap;
 
 @Encoding
 public class ImmutableMapEncoding<K, V> {
@@ -48,7 +46,9 @@ public class ImmutableMapEncoding<K, V> {
       if (builder != null) {
         builder.put(key, value);
       } else if (map != null) {
-        builder = ImmutableMap.<K, V>builderWithExpectedSize(map.size() + 1)
+        builder =
+          ImmutableMap
+            .<K, V>builderWithExpectedSize(map.size() + 1)
             .putAll(map)
             .put(key, value);
 
@@ -65,7 +65,9 @@ public class ImmutableMapEncoding<K, V> {
       if (builder != null) {
         builder.put(entry);
       } else if (map != null) {
-        builder = ImmutableMap.<K, V>builderWithExpectedSize(map.size() + 1)
+        builder =
+          ImmutableMap
+            .<K, V>builderWithExpectedSize(map.size() + 1)
             .putAll(map)
             .put(entry);
 
@@ -82,7 +84,9 @@ public class ImmutableMapEncoding<K, V> {
       if (builder != null) {
         builder.putAll(elements);
       } else if (map != null) {
-        builder = ImmutableMap.<K, V>builderWithExpectedSize(map.size() + elements.size())
+        builder =
+          ImmutableMap
+            .<K, V>builderWithExpectedSize(map.size() + elements.size())
             .putAll(map)
             .putAll(elements);
 
@@ -120,6 +124,5 @@ public class ImmutableMapEncoding<K, V> {
         return ImmutableMap.of();
       }
     }
-
   }
 }

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableSetEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableSetEncoding.java
@@ -1,16 +1,14 @@
 package com.hubspot.immutable.collection.encoding;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import org.immutables.encode.Encoding;
-import org.immutables.encode.Encoding.Naming;
-import org.immutables.encode.Encoding.StandardNaming;
-
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.immutables.encode.Encoding;
+import org.immutables.encode.Encoding.Naming;
+import org.immutables.encode.Encoding.StandardNaming;
 
 @Encoding
 public class ImmutableSetEncoding<T> {
@@ -28,13 +26,11 @@ public class ImmutableSetEncoding<T> {
     return field;
   }
 
-
   @Encoding.Copy
   @Naming(standard = StandardNaming.WITH)
   ImmutableSet<T> withCollectionVarargs(T... elements) {
     return ImmutableSet.copyOf(elements);
   }
-
 
   @Encoding.Copy
   @Naming(standard = StandardNaming.WITH)
@@ -60,7 +56,9 @@ public class ImmutableSetEncoding<T> {
       if (builder != null) {
         builder.add(element);
       } else if (set != null) {
-        builder = ImmutableSet.<T>builderWithExpectedSize(set.size() + 1)
+        builder =
+          ImmutableSet
+            .<T>builderWithExpectedSize(set.size() + 1)
             .addAll(set)
             .add(element);
 
@@ -82,7 +80,9 @@ public class ImmutableSetEncoding<T> {
           additionalSize = ((Collection<? extends T>) elements).size();
         }
 
-        builder = ImmutableSet.<T>builderWithExpectedSize(set.size() + additionalSize)
+        builder =
+          ImmutableSet
+            .<T>builderWithExpectedSize(set.size() + additionalSize)
             .addAll(set)
             .addAll(elements);
 
@@ -91,7 +91,10 @@ public class ImmutableSetEncoding<T> {
         if (elements instanceof ImmutableCollection) {
           set(elements);
         } else if (elements instanceof Collection) {
-          builder = ImmutableSet.builderWithExpectedSize(((Collection<? extends T>) elements).size());
+          builder =
+            ImmutableSet.builderWithExpectedSize(
+              ((Collection<? extends T>) elements).size()
+            );
           builder.addAll(elements);
         } else {
           builder = ImmutableSet.builder();

--- a/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
+++ b/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/ImmutableConditions.java
@@ -1,21 +1,29 @@
 package com.hubspot.immutables.validation;
 
+import com.google.common.base.Strings;
 import java.util.Collection;
 import java.util.Optional;
-
 import javax.annotation.Nonnull;
-
-import com.google.common.base.Strings;
 
 public class ImmutableConditions {
 
-  public static void checkValid(boolean expression, String template, Object... arguments) {
+  public static void checkValid(
+    boolean expression,
+    String template,
+    Object... arguments
+  ) {
     if (!expression) {
-      throw new InvalidImmutableStateException(Strings.lenientFormat(template, arguments));
+      throw new InvalidImmutableStateException(
+        Strings.lenientFormat(template, arguments)
+      );
     }
   }
 
-  public static void checkNotEmpty(Collection<?> collection, String template, Object... arguments) {
+  public static void checkNotEmpty(
+    Collection<?> collection,
+    String template,
+    Object... arguments
+  ) {
     checkValid(!collection.isEmpty(), template, arguments);
   }
 
@@ -29,7 +37,11 @@ public class ImmutableConditions {
     return ref;
   }
 
-  public static <T> T checkPresent(Optional<T> maybe, String template, Object... arguments) {
+  public static <T> T checkPresent(
+    Optional<T> maybe,
+    String template,
+    Object... arguments
+  ) {
     checkValid(maybe.isPresent(), template, arguments);
     return maybe.get();
   }

--- a/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/InvalidImmutableStateException.java
+++ b/immutables-exceptions/src/main/java/com/hubspot/immutables/validation/InvalidImmutableStateException.java
@@ -1,6 +1,7 @@
 package com.hubspot.immutables.validation;
 
 public class InvalidImmutableStateException extends RuntimeException {
+
   public InvalidImmutableStateException(String message) {
     super(message);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.2</version>
+    <version>59.4</version>
   </parent>
 
   <groupId>com.hubspot.immutables</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.6</version>
+    <version>59.2</version>
   </parent>
 
   <groupId>com.hubspot.immutables</groupId>
@@ -21,14 +21,8 @@
   </modules>
 
   <properties>
-    <project.build.targetJdk>1.8</project.build.targetJdk>
-    <dep.assertj.version>3.17.1</dep.assertj.version>
-    <dep.plugin.duplicate-finder.version>1.5.1</dep.plugin.duplicate-finder.version>
-    <dep.jackson.version>2.12.6</dep.jackson.version>
-    <dep.jackson-databind.version>${dep.jackson.version}</dep.jackson-databind.version>
-    <dep.immutables.version>2.8.8</dep.immutables.version>
-    <dep.guava.version>31.1-jre</dep.guava.version>
-    <dep.error-prone.version>2.11.0</dep.error-prone.version>
+    <project.build.targetJdk>8</project.build.targetJdk>
+    <project.build.releaseJdk>8</project.build.releaseJdk>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR upgrades basepom version to 59, which includes some prettier formatting changes and dependency upgrades.

I will publish 1.5 prior to this PR, and merge this into 1.6-SNAPSHOT.
