### PR TITLE
Enable wse encoding by default on all styles

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
+import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -39,5 +40,6 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled
 @ImmutableMapEncodingEnabled
+@WireSafeEnumEncodingEnabled
 public @interface HubSpotImmutableStyle {
 }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
@@ -1,6 +1,7 @@
 package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -24,5 +25,6 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
   passAnnotations = ImmutableInherited.class
 )
+@WireSafeEnumEncodingEnabled
 public @interface HubSpotModifiableStyle {
 }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
@@ -1,6 +1,7 @@
 package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,5 +28,6 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
   passAnnotations = ImmutableInherited.class
 )
+@WireSafeEnumEncodingEnabled
 public @interface HubSpotStyle {
 }


### PR DESCRIPTION
This enables the WireSafeEncoding on `HubSpotStyle`, `HubSpotImmutableStyle` and `HubSpotModifiableStyle`

Doing some testing with mothership [here](https://private.hubteam.com/mothership/mission/968503) and seems like there might only be one or two repos I need to PR to fix

@stevie400 @Xcelled @jaredstehler 