### PR TITLE
Revert "Enable wse encoding by default on all styles"

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/encoding/WireSafeEnumEncoding.java
@@ -5,6 +5,7 @@ import org.immutables.encode.Encoding;
 import org.immutables.encode.Encoding.Naming;
 import org.immutables.encode.Encoding.StandardNaming;
 
+// Enabling this encoding may cause issues in some builds see https://github.com/HubSpot/hubspot-immutables/pull/54
 @Encoding
 class WireSafeEnumEncoding<T extends Enum<T>> {
 

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
-import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -40,6 +39,5 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled
 @ImmutableMapEncodingEnabled
-@WireSafeEnumEncodingEnabled
 public @interface HubSpotImmutableStyle {
 }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -25,6 +24,5 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
   passAnnotations = ImmutableInherited.class
 )
-@WireSafeEnumEncodingEnabled
 public @interface HubSpotModifiableStyle {
 }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
@@ -1,7 +1,6 @@
 package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.hubspot.immutables.encoding.WireSafeEnumEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -28,6 +27,5 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
   passAnnotations = ImmutableInherited.class
 )
-@WireSafeEnumEncodingEnabled
 public @interface HubSpotStyle {
 }


### PR DESCRIPTION
For some reason, this encoding is causing an issue in some builds (the error here is quite obscure)

```[ERROR] error: org.immutables.value.internal.$processor$.$Processor threw java.lang.UnsupportedOperationException: ErrorType type not supported
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$TypeExtractor$TypeConverter.visitError($TypeExtractor.java:152)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$TypeExtractor$TypeConverter.visitError($TypeExtractor.java:96)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.code.Type$ErrorType.accept(Type.java:2407)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$TypeExtractor.getBounds($TypeExtractor.java:87)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$TypeExtractor.initParameters($TypeExtractor.java:77)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$TypeExtractor.<init>($TypeExtractor.java:46)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$Instantiator$InstantiationCreator.<init>($Instantiator.java:107)
[ERROR]   	at org.immutables.value.internal.$processor$.encode.$Instantiator.creatorFor($Instantiator.java:58)
[ERROR]   	at org.immutables.value.internal.$processor$.meta.$AccessorAttributesCollector.collect($AccessorAttributesCollector.java:82)
[ERROR]   	at org.immutables.value.internal.$processor$.meta.$ValueTypeComposer.compose($ValueTypeComposer.java:67)
[ERROR]   	at org.immutables.value.internal.$processor$.meta.$Round.composeValue($Round.java:181)
[ERROR]   	at org.immutables.value.internal.$processor$.meta.$Round.collectValues($Round.java:95)
[ERROR]   	at org.immutables.value.internal.$processor$.$Processor.process($Processor.java:79)
[ERROR]   	at org.immutables.value.internal.$generator$.$AbstractGenerator.process($AbstractGenerator.java:87)
[ERROR]   	at org.immutables.processor.ProxyProcessor.process(ProxyProcessor.java:72)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:1021)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.java:937)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1265)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1380)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1272)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:946)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
[ERROR]   	at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)```

Its not totally clear how the WSE encoding even became involved here because the repo in question does not (AFAICT) use WSE. Regardless, bisecting points to this commit as having caused the issue, so I am reverting for now to make 1.7 useable so we can get #53 out.

