### PR TITLE
Ensure that HubSpot style will pass rosetta annotations into Immutables

### DIFF
--- a/hubspot-style/pom.xml
+++ b/hubspot-style/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>com.hubspot.rosetta</groupId>
       <artifactId>RosettaAnnotations</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.hubspot.rosetta</groupId>

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotImmutableStyle.java
@@ -5,6 +5,7 @@ import com.hubspot.immutable.collection.encoding.ImmutableListEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableMapEncodingEnabled;
 import com.hubspot.immutable.collection.encoding.ImmutableSetEncodingEnabled;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
+import com.hubspot.rosetta.annotations.RosettaAnnotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -34,7 +35,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   optionalAcceptNullable = true, // allow for an Optional<T> to have a setter that takes a null value of T
   forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
-  passAnnotations = ImmutableInherited.class
+  passAnnotations = { ImmutableInherited.class, RosettaAnnotation.class }
 )
 @ImmutableSetEncodingEnabled
 @ImmutableListEncodingEnabled

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotModifiableStyle.java
@@ -2,6 +2,7 @@ package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
+import com.hubspot.rosetta.annotations.RosettaAnnotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,7 +23,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-  passAnnotations = ImmutableInherited.class
+  passAnnotations = { ImmutableInherited.class, RosettaAnnotation.class }
 )
 public @interface HubSpotModifiableStyle {
 }

--- a/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/style/HubSpotStyle.java
@@ -2,6 +2,7 @@ package com.hubspot.immutables.style;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hubspot.immutables.validation.InvalidImmutableStateException;
+import com.hubspot.rosetta.annotations.RosettaAnnotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -25,7 +26,7 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
   forceJacksonPropertyNames = false, // otherwise we can't use RosettaNamingStrategies
   visibility = ImplementationVisibility.SAME, // Generated class will have the same visibility as the abstract class/interface)
   jdkOnly = true, // For Guava 18+, this stops MoreObjects from being used in toString and ImmutableHashMap.Builder from being used for building map fields (among other effects).
-  passAnnotations = ImmutableInherited.class
+  passAnnotations = { ImmutableInherited.class, RosettaAnnotation.class }
 )
 public @interface HubSpotStyle {
 }

--- a/hubspot-style/src/test/java/com/hubspot/immutables/ImmutablesTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/ImmutablesTest.java
@@ -74,7 +74,7 @@ public class ImmutablesTest {
   @Test
   public void itDeserializesJson() throws IOException {
     String inputJson =
-      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
+      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true,\"hubspotCustomName\":13}";
     RosettaSprocket rosettaSprocket = objectMapper.readValue(
       inputJson,
       RosettaSprocket.class
@@ -84,6 +84,7 @@ public class ImmutablesTest {
     assertThat(rosettaSprocket.getName()).isEqualTo("test");
     assertThat(rosettaSprocket.getSomethingWithLongName()).isEqualTo("a long thing");
     assertThat(rosettaSprocket.isBlueSprocket()).isTrue();
+    assertThat(rosettaSprocket.getCustomName()).isEqualTo(13);
 
     JsonNode output = objectMapper.valueToTree(rosettaSprocket);
     JsonNode original = objectMapper.readTree(inputJson);
@@ -93,7 +94,7 @@ public class ImmutablesTest {
   @Test
   public void itDeserializesRosettaJson() throws IOException {
     String inputJson =
-      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
+      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true,\"hubspot_custom_name\":13}";
     RosettaSprocket rosettaSprocket = Rosetta
       .getMapper()
       .readValue(inputJson, RosettaSprocket.class);
@@ -102,6 +103,7 @@ public class ImmutablesTest {
     assertThat(rosettaSprocket.getName()).isEqualTo("test");
     assertThat(rosettaSprocket.getSomethingWithLongName()).isEqualTo("a long thing");
     assertThat(rosettaSprocket.isBlueSprocket()).isTrue();
+    assertThat(rosettaSprocket.getCustomName()).isEqualTo(13);
 
     JsonNode output = Rosetta.getMapper().valueToTree(rosettaSprocket);
     JsonNode original = Rosetta.getMapper().readTree(inputJson);
@@ -111,7 +113,7 @@ public class ImmutablesTest {
   @Test
   public void itDeserializesAnInterface() throws IOException {
     String inputJson =
-      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true}";
+      "{\"id\":1,\"hubSpotId\":12,\"name\":\"test\",\"somethingWithLongName\":\"a long thing\",\"blueSprocket\":true,\"hubspotCustomName\":13}";
     RosettaSprocketIF rosettaSprocketIF = objectMapper.readValue(
       inputJson,
       RosettaSprocketIF.class
@@ -121,6 +123,7 @@ public class ImmutablesTest {
     assertThat(rosettaSprocketIF.getName()).isEqualTo("test");
     assertThat(rosettaSprocketIF.getSomethingWithLongName()).isEqualTo("a long thing");
     assertThat(rosettaSprocketIF.isBlueSprocket()).isTrue();
+    assertThat(rosettaSprocketIF.getCustomName()).isEqualTo(13);
 
     JsonNode output = objectMapper.valueToTree(rosettaSprocketIF);
     JsonNode original = objectMapper.readTree(inputJson);
@@ -130,7 +133,7 @@ public class ImmutablesTest {
   @Test
   public void itDeserializesAnInterfaceFromRosetta() throws IOException {
     String inputJson =
-      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true}";
+      "{\"id\":1,\"hubspot_id\":12,\"name\":\"test\",\"something_with_long_name\":\"a long thing\",\"blue_sprocket\":true,\"hubspot_custom_name\":13}";
     RosettaSprocketIF rosettaSprocketIF = Rosetta
       .getMapper()
       .readValue(inputJson, RosettaSprocketIF.class);
@@ -139,6 +142,7 @@ public class ImmutablesTest {
     assertThat(rosettaSprocketIF.getName()).isEqualTo("test");
     assertThat(rosettaSprocketIF.getSomethingWithLongName()).isEqualTo("a long thing");
     assertThat(rosettaSprocketIF.isBlueSprocket()).isTrue();
+    assertThat(rosettaSprocketIF.getCustomName()).isEqualTo(13);
 
     JsonNode output = Rosetta.getMapper().valueToTree(rosettaSprocketIF);
     JsonNode original = Rosetta.getMapper().readTree(inputJson);

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
@@ -1,5 +1,6 @@
 package com.hubspot.immutables.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.hubspot.immutables.style.HubSpotStyle;
@@ -16,6 +17,10 @@ public interface RosettaSprocketIF {
 
   @RosettaProperty("hubspot_id")
   int getHubSpotId();
+
+  @JsonProperty("hubspotCustomName")
+  @RosettaProperty("hubspot_custom_name")
+  int getCustomName();
 
   String getName();
   String getSomethingWithLongName();


### PR DESCRIPTION
This PR ensures that Rosetta annotations get passes along into the immtable object definitions and resolves when we define an immutable like 

```
@Immutable
@HubSpotStyle
@RosettaNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
public interface ObjectWithBooleanTestIF {
  @JsonSetter("someValue")
  @JsonProperty("isSomeValue")
  @RosettaProperty("is_some_value")
  Optional<Boolean> isSomeValue();
}
```
Rosetta will serialize to `{'is_some_value':true}` but deserialization will only happen wen defining `{'someValue':true}` sicne the RosettaProperty is not passed into the generated immutable class.

cc @stevie400 @Xcelled @jhaber @jaredstehler 