### PR TITLE
Never return null immutable collection

### DIFF
--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithParamAndDefaultIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithParamAndDefaultIF.java
@@ -1,0 +1,18 @@
+package com.hubspot.immutable.collection.encoding.test;
+
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value.Default;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+@Immutable
+@TestStyle
+public interface TestListWithParamAndDefaultIF {
+  @Parameter
+  String getName();
+
+  @Default
+  default ImmutableList<String> getStrings() {
+    return ImmutableList.of("default");
+  }
+}

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithParamIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestListWithParamIF.java
@@ -1,0 +1,14 @@
+package com.hubspot.immutable.collection.encoding.test;
+
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+@Immutable
+@TestStyle
+public interface TestListWithParamIF {
+  @Parameter
+  String getName();
+
+  ImmutableList<String> getStrings();
+}

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestMapWithParamIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestMapWithParamIF.java
@@ -1,0 +1,14 @@
+package com.hubspot.immutable.collection.encoding.test;
+
+import com.google.common.collect.ImmutableMap;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+@Immutable
+@TestStyle
+public interface TestMapWithParamIF {
+  @Parameter
+  String getName();
+
+  ImmutableMap<String, String> getStrings();
+}

--- a/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestSetWithParamIF.java
+++ b/immutable-collection-encodings-test/src/main/java/com/hubspot/immutable/collection/encoding/test/TestSetWithParamIF.java
@@ -1,0 +1,14 @@
+package com.hubspot.immutable.collection.encoding.test;
+
+import com.google.common.collect.ImmutableSet;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Parameter;
+
+@Immutable
+@TestStyle
+public interface TestSetWithParamIF {
+  @Parameter
+  String getName();
+
+  ImmutableSet<String> getStrings();
+}

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
@@ -144,9 +144,14 @@ public class ImmutableListEncodingTest {
   }
 
   @Test
-  public void itDoesInitializeCollectionWhenBuildingFromParam()
-    throws JsonProcessingException {
+  public void itDoesInitializeCollectionWhenBuildingFromParam() {
     TestListWithParam param = TestListWithParam.of("test");
     assertThat(param.getStrings()).isNotNull();
+  }
+
+  @Test
+  public void itDoesHaveCorrectDefaultWhenBuildingFromParam() {
+    TestListWithParamAndDefault param = TestListWithParamAndDefault.of("test");
+    assertThat(param.getStrings()).containsExactly("default");
   }
 }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableListEncodingTest.java
@@ -142,4 +142,11 @@ public class ImmutableListEncodingTest {
     TestListWithDefault test = MAPPER.readValue(INPUT_JSON, TestListWithDefault.class);
     assertThat(test.getInts()).containsExactly(1);
   }
+
+  @Test
+  public void itDoesInitializeCollectionWhenBuildingFromParam()
+    throws JsonProcessingException {
+    TestListWithParam param = TestListWithParam.of("test");
+    assertThat(param.getStrings()).isNotNull();
+  }
 }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableMapEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableMapEncodingTest.java
@@ -113,4 +113,10 @@ public class ImmutableMapEncodingTest {
     TestMapWithDefault test = MAPPER.readValue(INPUT_JSON, TestMapWithDefault.class);
     assertThat(test.getInts()).containsKey("one");
   }
+
+  @Test
+  public void itDoesInitializeCollectionWhenBuildingFromParam() {
+    TestMapWithParam param = TestMapWithParam.of("test");
+    assertThat(param.getStrings()).isNotNull();
+  }
 }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
@@ -134,4 +134,11 @@ public class ImmutableSetEncodingTest {
     TestSetWithDefault test = MAPPER.readValue(INPUT_JSON, TestSetWithDefault.class);
     assertThat(test.getInts()).containsExactly(1);
   }
+
+  @Test
+  public void itDoesInitializeCollectionWhenBuildingFromParam()
+    throws JsonProcessingException {
+    TestSetWithParam param = TestSetWithParam.of("test");
+    assertThat(param.getStrings()).isNotNull();
+  }
 }

--- a/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
+++ b/immutable-collection-encodings-test/src/test/java/com/hubspot/immutable/collection/encoding/test/ImmutableSetEncodingTest.java
@@ -136,8 +136,7 @@ public class ImmutableSetEncodingTest {
   }
 
   @Test
-  public void itDoesInitializeCollectionWhenBuildingFromParam()
-    throws JsonProcessingException {
+  public void itDoesInitializeCollectionWhenBuildingFromParam() {
     TestSetWithParam param = TestSetWithParam.of("test");
     assertThat(param.getStrings()).isNotNull();
   }

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableListEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableListEncoding.java
@@ -16,12 +16,20 @@ public class ImmutableListEncoding<T> {
 
   @Encoding.Expose
   ImmutableList<T> getImmutableList() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableList.of();
+    }
   }
 
   @Encoding.Expose
   List<T> getList() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableList.of();
+    }
   }
 
   @Encoding.Copy

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableMapEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableMapEncoding.java
@@ -14,12 +14,20 @@ public class ImmutableMapEncoding<K, V> {
 
   @Encoding.Expose
   ImmutableMap<K, V> getImmutableMap() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableMap.of();
+    }
   }
 
   @Encoding.Expose
   Map<K, V> getMap() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableMap.of();
+    }
   }
 
   @Encoding.Copy

--- a/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableSetEncoding.java
+++ b/immutable-collection-encodings/src/main/java/com/hubspot/immutable/collection/encoding/ImmutableSetEncoding.java
@@ -16,12 +16,20 @@ public class ImmutableSetEncoding<T> {
 
   @Encoding.Expose
   ImmutableSet<T> getImmutableSet() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableSet.of();
+    }
   }
 
   @Encoding.Expose
   Set<T> getSet() {
-    return field;
+    if (field != null) {
+      return field;
+    } else {
+      return ImmutableSet.of();
+    }
   }
 
   @Encoding.Copy


### PR DESCRIPTION
This is a follow up on #53 which changed the collection initialization to `null` by default. Initializing to `null` is fine in most cases b/c the immutable will be built via the builder, which checks for null by doing:

```java
      if (builder != null) {
        return builder.build();
      } else if (list != null) {
        return list;
      } else {
        return ImmutableList.of();
      }
```

However, when you use the `@Param` annotation, immutables will generate a constructor that entirely skips the builder:

```java
  private TestListWithParam(String name) {
    this.name = Objects.requireNonNull(name, "name");
    this.strings = null;
    this.initShim = null;
  }
```

Unfortunately I can't see any to customize this constructor, so setting to null here seems to be the only choice, to work around this I have made the getters return the correct empty collection value when the attribute is null.

Note that this still works when the collection value has a default b/c the generated constructor in that case looks like:

```java
  private TestListWithParamAndDefault(String name) {
    this.name = Objects.requireNonNull(name, "name");
    this.strings = initShim.getStrings();
    this.initShim = null;
  }
```

and that `initShim.getStrings()` handles the default value.