### PR TITLE
Fix deprecated wrongTokenException calls

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -358,7 +358,7 @@ public final class WireSafeEnum<T extends Enum<T>> {
               (klass, value) -> create(enumType, value, p, ctxt)
             );
           } else {
-            throw ctxt.wrongTokenException(p, JsonToken.VALUE_STRING, null);
+            throw ctxt.wrongTokenException(p, enumType, JsonToken.VALUE_STRING, null);
           }
         }
       };


### PR DESCRIPTION
This is to fix usage of deprecated usage of wrongTokenException which was removed in jackson 2.16