### PR TITLE
Adds support for Jackson 2.18

### DIFF
--- a/hubspot-style-test/pom.xml
+++ b/hubspot-style-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hubspot-style-test</artifactId>

--- a/hubspot-style/pom.xml
+++ b/hubspot-style/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hubspot-style</artifactId>

--- a/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/model/RosettaSprocketIF.java
@@ -1,7 +1,7 @@
 package com.hubspot.immutables.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.hubspot.immutables.style.HubSpotStyle;
 import com.hubspot.rosetta.annotations.RosettaNaming;
@@ -10,7 +10,7 @@ import org.immutables.value.Value;
 
 @HubSpotStyle
 @Value.Immutable
-@RosettaNaming(value = LowerCaseWithUnderscoresStrategy.class)
+@RosettaNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonDeserialize(as = RosettaSprocket.class)
 public interface RosettaSprocketIF {
   int getId();

--- a/immutable-collection-encodings-test/pom.xml
+++ b/immutable-collection-encodings-test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>immutable-collection-encodings-test</artifactId>

--- a/immutable-collection-encodings/pom.xml
+++ b/immutable-collection-encodings/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>immutable-collection-encodings</artifactId>

--- a/immutables-exceptions/pom.xml
+++ b/immutables-exceptions/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.immutables</groupId>
     <artifactId>hubspot-immutables</artifactId>
-    <version>1.10.2-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>immutables-exceptions</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>61.2</version>
+    <version>62.1</version>
   </parent>
 
   <groupId>com.hubspot.immutables</groupId>
   <artifactId>hubspot-immutables</artifactId>
-  <version>1.10.2-SNAPSHOT</version>
+  <version>1.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -25,7 +25,7 @@
     <project.build.targetJdk>8</project.build.targetJdk>
     <project.build.releaseJdk>8</project.build.releaseJdk>
 
-    <dep.rosetta.version>3.12.2</dep.rosetta.version>
+    <dep.rosetta.version>3.13.0</dep.rosetta.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
* use specific KeyDeserializer, as `FactoryBasedEnumDeserializer` will throw error for `@JsonCreator` and `JsonToken.FIELD_NAME`
* replace deprecated / removed exception creator methods
* bump basepom to 62.1, which includes an update of jackson from 2.12 to 2.18

@PtrTeixeira @ggs5427 @tkindy 
