### PR TITLE
Add contains any of

### DIFF
--- a/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
+++ b/hubspot-style/src/main/java/com/hubspot/immutables/utils/WireSafeEnum.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
 import com.fasterxml.jackson.databind.deser.ContextualKeyDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.immutables.utils.WireSafeEnum.Deserializer;
 import com.hubspot.immutables.utils.WireSafeEnum.KeyDeserializer;
 import java.io.IOException;
@@ -179,6 +180,18 @@ public final class WireSafeEnum<T extends Enum<T>> {
     checkNotNull(value, "value");
 
     return enumValue.isPresent() && enumValue.get() == value;
+  }
+
+  @SafeVarargs
+  public final boolean containsAnyOf(@Nonnull T... values) {
+    checkNotNull(values, "values");
+    // copy-of doesn't alloc on empty input
+    return containsAnyOf(ImmutableSet.copyOf(values));
+  }
+
+  public boolean containsAnyOf(@Nonnull Collection<T> values) {
+    checkNotNull(values, "values");
+    return enumValue.isPresent() && values.contains(enumValue.get());
   }
 
   @Override

--- a/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
+++ b/hubspot-style/src/test/java/com/hubspot/immutables/utils/WireSafeEnumTest.java
@@ -214,6 +214,17 @@ public class WireSafeEnumTest {
   }
 
   @Test
+  public void itCanCheckContains() {
+    WireSafeEnum<EnumWithOverride> abc = WireSafeEnum.of(EnumWithOverride.ABC);
+    WireSafeEnum<EnumWithOverride> def = WireSafeEnum.of(EnumWithOverride.DEF);
+
+    assertThat(abc.contains(EnumWithOverride.ABC)).isTrue();
+    assertThat(abc.contains(EnumWithOverride.DEF)).isFalse();
+    assertThat(abc.containsAnyOf(EnumWithOverride.ABC, EnumWithOverride.DEF)).isTrue();
+    assertThat(def.containsAnyOf(EnumWithOverride.ABC, EnumWithOverride.DEF)).isTrue();
+  }
+
+  @Test
   public void itParsesNullAsNull() throws IOException {
     WireSafeEnum<RetentionPolicy> wrapper = MAPPER.readValue(
       "null",


### PR DESCRIPTION
A minor optimization / QoL feature to replace code like this
```java
boolean isThing = wse.contains(MyEnum.ONE) || wse.contains(MyEnum.TWO);
if (isThing) {
 // do stuff
}
```

Seems worth it to me to add, but happy to get other opinions

@Xcelled @mjball @suruuK @jaredstehler 