### PR TITLE
fix(build): expose module licenses in generated license reports

### DIFF
--- a/hubspot-style-test/pom.xml
+++ b/hubspot-style-test/pom.xml
@@ -45,4 +45,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/hubspot-style/pom.xml
+++ b/hubspot-style/pom.xml
@@ -80,4 +80,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/immutable-collection-encodings-test/pom.xml
+++ b/immutable-collection-encodings-test/pom.xml
@@ -65,4 +65,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/immutable-collection-encodings/pom.xml
+++ b/immutable-collection-encodings/pom.xml
@@ -30,4 +30,11 @@
       <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>

--- a/immutables-exceptions/pom.xml
+++ b/immutables-exceptions/pom.xml
@@ -21,4 +21,11 @@
       <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
 </project>


### PR DESCRIPTION
# Description of Changes

Added Apache License 2.0 metadata to the Maven POM files for:

- `hubspot-style`
- `hubspot-style-test`
- `immutable-collection-encodings`
- `immutables-exceptions`

This change ensures that the modules' license is detected and displayed.

Previously, no license information was shown for these modules because their POM files did not explicitly declare a license.

## Why the license metadata was not detected

`com.github.jk1.dependency-license-report` derives license information from the Maven metadata of each resolved dependency rather than from the repository's `LICENSE` file.

The affected module POMs did not contain their own `<licenses>` section. The Apache 2.0 license was declared only in the parent project POM. Although the plugin supports collecting licenses from parent POMs, this depends on the complete parent POM chain being resolved and interpreted correctly. For these artifacts, that inherited license did not result in usable module-level license metadata, so the modules appeared without a license in `checkLicense` and `generateLicenseReport`.

Declaring the Apache 2.0 license directly in every published module POM makes each artifact's metadata self-contained. This allows the plugin to detect the license reliably without depending on parent POM traversal.